### PR TITLE
Fix undeclared errors of EM_ARM and EM_AARCH64

### DIFF
--- a/tools/util.h
+++ b/tools/util.h
@@ -42,6 +42,22 @@
 				 __AUDIT_ARCH_CONVENTION_MIPS64_N32)
 #endif
 
+#ifndef EM_ARM
+#define EM_ARM 40
+#endif
+
+#ifndef AUDIT_ARCH_ARM
+#define AUDIT_ARCH_ARM          (EM_ARM|__AUDIT_ARCH_LE)
+#endif
+
+#ifndef AUDIT_ARCH_ARMEB
+#define AUDIT_ARCH_ARMEB        (EM_ARM)
+#endif
+
+#ifndef EM_AARCH64
+#define EM_AARCH64 183
+#endif
+
 #ifndef AUDIT_ARCH_AARCH64
 /* AArch64 support for audit was merged in 3.17-rc1 */
 #define AUDIT_ARCH_AARCH64	(EM_AARCH64|__AUDIT_ARCH_64BIT|__AUDIT_ARCH_LE)


### PR DESCRIPTION
This happens when using toolchains with old kernel headers, and
generates errors like these ones:

----------------------------------
scmp_bpf_disasm.c:322:12: error: 'EM_ARM' undeclared (first use in this
function)

util.h:46:29: error: 'EM_AARCH64' undeclared (first use in this
function)
----------------------------------

Full log can be found here:

  http://autobuild.buildroot.net/results/4cd/4cd6aaccde9fb0f80e49133b477f330b601f4a63/build-end.log

Signed-off-by: Vicente Olivert Riera <Vincent.Riera@imgtec.com>