### PR TITLE
fix == bashism

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -121,7 +121,7 @@ AS_IF([test "$enable_python" = yes], [
 ])
 AM_CONDITIONAL([ENABLE_PYTHON], [test "$enable_python" = yes])
 AC_DEFINE_UNQUOTED([ENABLE_PYTHON],
-	[$(test "$enable_python" == yes && echo 1 || echo 0)],
+	[$(test "$enable_python" = yes && echo 1 || echo 0)],
 	[Python bindings build flag.])
 
 dnl ####


### PR DESCRIPTION
The test tool only has = for comparison, not ==.  The latter is accepted
by bash and other shells, but is not in POSIX.