### PR TITLE
system.h: Remove conflicting kernel header include

### DIFF
--- a/src/system.h
+++ b/src/system.h
@@ -23,7 +23,6 @@
 #define _SYSTEM_H
 
 #include <linux/filter.h>
-#include <linux/prctl.h>
 
 #include "configure.h"
 


### PR DESCRIPTION
This fixes building on musl libc, since musl does not include kernel
headers. I've tested this as working on both glibc and musl.

Signed-off-by: Kylie McClain <somasis@exherbo.org>