### PR TITLE
BUG: fix typo in seccomp_merge.3

### DIFF
--- a/doc/man/man3/seccomp_merge.3
+++ b/doc/man/man3/seccomp_merge.3
@@ -29,7 +29,7 @@ and stores the resulting in the
 .I dst
 filter.  If successfull, the
 .I src
-seccomp filter is released and all internal memory assocated with the filter
+seccomp filter is released and all internal memory associated with the filter
 is freed; there is no need to call
 .BR seccomp_release (3)
 on


### PR DESCRIPTION
Minor typo fix: s/assocated/associated/