### PR TITLE
man: clarify SCMP_FLTATR_CTL_NNP semantic

### DIFF
--- a/doc/man/man3/seccomp_attr_set.3
+++ b/doc/man/man3/seccomp_attr_set.3
@@ -59,10 +59,11 @@ action.
 .TP
 .B SCMP_FLTATR_CTL_NNP
 A flag to specify if the NO_NEW_PRIVS functionality should be enabled before
-loading the seccomp filter into the kernel.  If set to off (
+loading the seccomp filter into the kernel.  Setting this to off (
 .I value
-== 0) then loading the seccomp filter into the kernel will fail if CAP_SYS_ADMIN
-is not set.  Defaults to on (
+== 0) results in no action, meaning that loading the seccomp filter into the
+kernel will fail if CAP_SYS_ADMIN is missing and NO_NEW_PRIVS has not been
+externally set.  Defaults to on (
 .I value
 == 1).
 .TP


### PR DESCRIPTION
Clarify that the zero value results in a no-op on libseccomp
side, and applications will need to have to have proper caps
or set NO_NEW_PRIVS by themself.

Signed-off-by: Luca Bruno <lucab@debian.org>