### PR TITLE
RFE: add support for SECCOMP_RET_AUDIT

### DIFF
--- a/include/seccomp.h.in
+++ b/include/seccomp.h.in
@@ -256,6 +256,10 @@ struct scmp_arg_cmp {
  */
 #define SCMP_ACT_TRACE(x)	(0x7ff00000U | ((x) & 0x0000ffffU))
 /**
+ * Allow the syscall to be executed after an audit message is emitted
+ */
+#define SCMP_ACT_AUDIT		0x7ffe0000U
+/**
  * Allow the syscall to be executed
  */
 #define SCMP_ACT_ALLOW		0x7fff0000U

--- a/src/db.c
+++ b/src/db.c
@@ -652,6 +652,8 @@ int db_action_valid(uint32_t action)
 		return 0;
 	else if (action == SCMP_ACT_TRACE(action & 0x0000ffff))
 		return 0;
+	else if (action == SCMP_ACT_AUDIT)
+		return 0;
 	else if (action == SCMP_ACT_ALLOW)
 		return 0;
 

--- a/src/gen_pfc.c
+++ b/src/gen_pfc.c
@@ -129,6 +129,9 @@ static void _pfc_action(FILE *fds, uint32_t action)
 	case SCMP_ACT_TRACE(0):
 		fprintf(fds, "action TRACE(%u);\n", (action & 0x0000ffff));
 		break;
+	case SCMP_ACT_AUDIT:
+		fprintf(fds, "action AUDIT;\n");
+		break;
 	case SCMP_ACT_ALLOW:
 		fprintf(fds, "action ALLOW;\n");
 		break;

--- a/src/python/libseccomp.pxd
+++ b/src/python/libseccomp.pxd
@@ -69,6 +69,7 @@ cdef extern from "seccomp.h":
     cdef enum:
         SCMP_ACT_KILL
         SCMP_ACT_TRAP
+        SCMP_ACT_AUDIT
         SCMP_ACT_ALLOW
     unsigned int SCMP_ACT_ERRNO(int errno)
     unsigned int SCMP_ACT_TRACE(int value)

--- a/src/python/seccomp.pyx
+++ b/src/python/seccomp.pyx
@@ -30,6 +30,7 @@ by application developers.
 
 Filter action values:
     KILL - kill the process
+    AUDIT - allow the syscall to execute after an audit message is emitted
     ALLOW - allow the syscall to execute
     TRAP - a SIGSYS signal will be thrown
     ERRNO(x) - syscall will return (x)
@@ -77,6 +78,7 @@ cimport libseccomp
 
 KILL = libseccomp.SCMP_ACT_KILL
 TRAP = libseccomp.SCMP_ACT_TRAP
+AUDIT = libseccomp.SCMP_ACT_AUDIT
 ALLOW = libseccomp.SCMP_ACT_ALLOW
 def ERRNO(int errno):
     """The action ERRNO(x) means that the syscall will return (x).
@@ -493,7 +495,7 @@ cdef class SyscallFilter:
         """ Add a new rule to filter.
 
         Arguments:
-        action - the rule action: KILL, TRAP, ERRNO(), TRACE(), or ALLOW
+        action - the rule action: KILL, TRAP, ERRNO(), TRACE(), AUDIT, or ALLOW
         syscall - the syscall name or number
         args - variable number of Arg objects
 
@@ -575,7 +577,7 @@ cdef class SyscallFilter:
         """ Add a new rule to filter.
 
         Arguments:
-        action - the rule action: KILL, TRAP, ERRNO(), TRACE(), or ALLOW
+        action - the rule action: KILL, TRAP, ERRNO(), TRACE(), AUDIT, or ALLOW
         syscall - the syscall name or number
         args - variable number of Arg objects
 

--- a/src/system.h
+++ b/src/system.h
@@ -59,6 +59,7 @@ struct db_filter_col;
 #define SECCOMP_RET_TRAP	0x00030000U /* disallow and force a SIGSYS */
 #define SECCOMP_RET_ERRNO	0x00050000U /* returns an errno */
 #define SECCOMP_RET_TRACE	0x7ff00000U /* pass to a tracer or disallow */
+#define SECCOMP_RET_AUDIT	0x7ffe0000U /* allow with an audit message */
 #define SECCOMP_RET_ALLOW	0x7fff0000U /* allow */
 
 /* Masks for the return value sections. */

--- a/tests/06-sim-actions.c
+++ b/tests/06-sim-actions.c
@@ -44,6 +44,10 @@ int main(int argc, char *argv[])
 	if (rc != 0)
 		goto out;
 
+	rc = seccomp_rule_add(ctx, SCMP_ACT_AUDIT, SCMP_SYS(rt_sigreturn), 0);
+	if (rc != 0)
+		goto out;
+
 	rc = seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(write), 0);
 	if (rc != 0)
 		goto out;

--- a/tests/06-sim-actions.py
+++ b/tests/06-sim-actions.py
@@ -32,6 +32,7 @@ from seccomp import *
 def test(args):
     f = SyscallFilter(KILL)
     f.add_rule(ALLOW, "read")
+    f.add_rule(AUDIT, "rt_sigreturn")
     f.add_rule(ERRNO(errno.EPERM), "write")
     f.add_rule(TRAP, "close")
     f.add_rule(TRACE(1234), "open")

--- a/tests/06-sim-actions.tests
+++ b/tests/06-sim-actions.tests
@@ -7,14 +7,17 @@
 
 test type: bpf-sim
 
-# Testname	Arch		Syscall	Arg0		Arg1		Arg2	Arg3	Arg4	Arg5	Result
-06-sim-actions	all		read	4		0x856B008	80	N	N	N	ALLOW
-06-sim-actions	all		write	1		0x856B008	N	N	N	N	ERRNO(1)
-06-sim-actions	all		close	4		N		N	N	N	N	TRAP
-06-sim-actions	all,-aarch64	open	0x856B008	4		N	N	N	N	TRACE(1234)
-06-sim-actions	x86		0-2	N		N		N	N	N	N	KILL
-06-sim-actions	x86		7-350	N		N		N	N	N	N	KILL
-06-sim-actions	x86_64		4-350	N		N		N	N	N	N	KILL
+# Testname	Arch		Syscall		Arg0		Arg1		Arg2	Arg3	Arg4	Arg5	Result
+06-sim-actions	all		read		4		0x856B008	80	N	N	N	ALLOW
+06-sim-actions	all		write		1		0x856B008	N	N	N	N	ERRNO(1)
+06-sim-actions	all		close		4		N		N	N	N	N	TRAP
+06-sim-actions	all,-aarch64	open		0x856B008	4		N	N	N	N	TRACE(1234)
+06-sim-actions	all		rt_sigreturn	N		N		N	N	N	N	AUDIT
+06-sim-actions	x86		0-2		N		N		N	N	N	N	KILL
+06-sim-actions	x86		7-172		N		N		N	N	N	N	KILL
+06-sim-actions	x86		174-350		N		N		N	N	N	N	KILL
+06-sim-actions	x86_64		4-14		N		N		N	N	N	N	KILL
+06-sim-actions	x86_64		16-350		N		N		N	N	N	N	KILL
 
 test type: bpf-sim-fuzz
 

--- a/tests/35-sim-audit.c
+++ b/tests/35-sim-audit.c
@@ -1,0 +1,52 @@
+/**
+ * Seccomp Library test program
+ *
+ * Originally 01-sim-allow.c but updated to use SCMP_ACT_AUDIT.
+ *
+ * Copyright (c) 2012 Red Hat <pmoore@redhat.com>
+ * Author: Paul Moore <paul@paul-moore.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include <errno.h>
+#include <unistd.h>
+
+#include <seccomp.h>
+
+#include "util.h"
+
+int main(int argc, char *argv[])
+{
+	int rc;
+	struct util_options opts;
+	scmp_filter_ctx ctx = NULL;
+
+	rc = util_getopt(argc, argv, &opts);
+	if (rc < 0)
+		goto out;
+
+	ctx = seccomp_init(SCMP_ACT_AUDIT);
+	if (ctx == NULL)
+		return ENOMEM;
+
+	rc = util_filter_output(&opts, ctx);
+	if (rc)
+		goto out;
+
+out:
+	seccomp_release(ctx);
+	return (rc < 0 ? -rc : rc);
+}

--- a/tests/35-sim-audit.py
+++ b/tests/35-sim-audit.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+#
+# Seccomp Library test program
+#
+# Originally 01-sim-allow.py but updated to use AUDIT.
+#
+# Copyright (c) 2012 Red Hat <pmoore@redhat.com>
+# Author: Paul Moore <paul@paul-moore.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+import argparse
+import sys
+
+import util
+
+from seccomp import *
+
+def test(args):
+    f = SyscallFilter(AUDIT)
+    return f
+
+args = util.get_opt()
+ctx = test(args)
+util.filter_output(args, ctx)
+
+# kate: syntax python;
+# kate: indent-mode python; space-indent on; indent-width 4; mixedindent off;

--- a/tests/35-sim-audit.tests
+++ b/tests/35-sim-audit.tests
@@ -1,0 +1,23 @@
+#
+# libseccomp regression test automation data
+#
+# Originally 01-sim-allow.tests but updated for AUDIT
+#
+# Copyright IBM Corp. 2012
+# Author: Corey Bryant <coreyb@linux.vnet.ibm.com>
+#
+
+test type: bpf-sim
+
+# Testname	Arch	Syscall	Arg0	Arg1	Arg2	Arg3	Arg4	Arg5	Result
+35-sim-audit	all	0-350	N	N	N	N	N	N	AUDIT
+
+test type: bpf-sim-fuzz
+
+# Testname	StressCount
+35-sim-audit	50
+
+test type: bpf-valgrind
+
+# Testname
+35-sim-audit

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -62,7 +62,8 @@ check_PROGRAMS = \
 	31-basic-version_check \
 	32-live-tsync_allow \
 	33-sim-socket_syscalls_be \
-	34-sim-basic_blacklist
+	34-sim-basic_blacklist \
+	35-sim-audit
 
 EXTRA_DIST_TESTPYTHON = \
 	util.py \
@@ -99,7 +100,8 @@ EXTRA_DIST_TESTPYTHON = \
 	31-basic-version_check.py \
 	32-live-tsync_allow.py \
 	33-sim-socket_syscalls_be.py \
-	34-sim-basic_blacklist.py
+	34-sim-basic_blacklist.py \
+	35-sim-audit.py
 
 EXTRA_DIST_TESTCFGS = \
 	01-sim-allow.tests \
@@ -135,7 +137,8 @@ EXTRA_DIST_TESTCFGS = \
 	31-basic-version_check.tests \
 	32-live-tsync_allow.tests \
 	33-sim-socket_syscalls_be.tests \
-	34-sim-basic_blacklist.tests
+	34-sim-basic_blacklist.tests \
+	35-sim-audit.tests
 
 EXTRA_DIST_TESTSCRIPTS = regression testdiff testgen
 

--- a/tests/regression
+++ b/tests/regression
@@ -709,6 +709,7 @@ function run_test_live() {
 		rc_trap=161
 		rc_trace=162
 		rc_errno=163
+		rc_audit=164
 		;;
 	mips|mipsel|mips64|mips64n32|mipsel64|mipsel64n32)
 		rc_kill=140
@@ -716,6 +717,7 @@ function run_test_live() {
 		rc_trap=161
 		rc_trace=162
 		rc_errno=163
+		rc_audit=164
 		;;
 	*)
 		print_result $testnumstr "ERROR" "arch $arch not supported"
@@ -738,6 +740,9 @@ function run_test_live() {
 		print_result $1 "ERROR" "unsupported action \"$line_act\""
 		stats_error=$(($stats_error+1))
 	elif [[ $line_act == "ERRNO" && $rc -eq $rc_errno ]]; then
+		print_result $1 "SUCCESS" ""
+		stats_success=$(($stats_success+1))
+	elif [[ $line_act == "AUDIT" && $rc -eq $rc_audit ]]; then
 		print_result $1 "SUCCESS" ""
 		stats_success=$(($stats_success+1))
 	else

--- a/tests/util.c
+++ b/tests/util.c
@@ -176,6 +176,8 @@ int util_action_parse(const char *action)
 		return -1; /* not yet supported */
 	else if (strcasecmp(action, "ALLOW") == 0)
 		return SCMP_ACT_ALLOW;
+	else if (strcasecmp(action, "AUDIT") == 0)
+		return SCMP_ACT_AUDIT;
 
 	return -1;
 }

--- a/tools/bpf.h
+++ b/tools/bpf.h
@@ -64,6 +64,7 @@ typedef struct sock_filter bpf_instr_raw;
 #define SECCOMP_RET_TRAP	0x00030000U
 #define SECCOMP_RET_ERRNO	0x00050000U
 #define SECCOMP_RET_TRACE	0x7ff00000U
+#define SECCOMP_RET_AUDIT	0x7ffe0000U
 #define SECCOMP_RET_ALLOW	0x7fff0000U
 
 /* bpf command classes */

--- a/tools/scmp_bpf_disasm.c
+++ b/tools/scmp_bpf_disasm.c
@@ -189,6 +189,9 @@ static void bpf_decode_action(uint32_t k)
 	case SECCOMP_RET_TRACE:
 		printf("TRACE(%u)", data);
 		break;
+	case SECCOMP_RET_AUDIT:
+		printf("AUDIT");
+		break;
 	case SECCOMP_RET_ALLOW:
 		printf("ALLOW");
 		break;

--- a/tools/scmp_bpf_sim.c
+++ b/tools/scmp_bpf_sim.c
@@ -128,6 +128,9 @@ static void end_action(uint32_t action, unsigned int line)
 	case SECCOMP_RET_TRACE:
 		fprintf(stdout, "TRACE(%u)\n", data);
 		break;
+	case SECCOMP_RET_AUDIT:
+		fprintf(stdout, "AUDIT\n");
+		break;
 	case SECCOMP_RET_ALLOW:
 		fprintf(stdout, "ALLOW\n");
 		break;


### PR DESCRIPTION
This pull request adds support for SECCOMP_RET_AUDIT which is a newly proposed seccomp return action that audits the syscall before allowing it to happen. It is similar to SECCOMP_RET_ALLOW in that the syscall is allowed but differs in that the syscall will be audited.