### PR TITLE
man: Fix SCMP_FLTATR_API_TSKIP typo in seccomp_attr_set man page

### DIFF
--- a/doc/man/man3/seccomp_attr_set.3
+++ b/doc/man/man3/seccomp_attr_set.3
@@ -78,7 +78,7 @@ error being returned.  Defaults to off (
 .I value
 == 0).
 .TP
-.B SCMP_FLTATR_ATL_TSKIP
+.B SCMP_FLTATR_API_TSKIP
 A flag to specify if libseccomp should allow filter rules to be created for
 the -1 syscall.  The -1 syscall value can be used by tracer programs to skip
 specific syscall invocations, see


### PR DESCRIPTION
Fix a minor but potentially confusing man page typo.