### PR TITLE
tests: fix conditional that was skipping all basic python tests

### DIFF
--- a/tests/regression
+++ b/tests/regression
@@ -608,7 +608,7 @@ function run_test_basic() {
 	local cmd
 
 	# if the test is a script, only run it in native/c mode
-	if [[ $mode != "c" && $(echo "$2" | grep -q '.sh$') -eq 0 ]]; then
+	if [[ $mode != "c" && "$2" == *.sh ]]; then
 		print_result "$1" "SKIPPED" "(only valid in native/c mode)"
 		stats_skipped=$(($stats_skipped+1))
 		return


### PR DESCRIPTION
A conditional added in ec6f45ab was incorrectly comparing the (empty)
stdout of grep -q against 0, which always evaluated to be true and
skipped the basic python tests.

Fix it by using bash's pattern matching.

Signed-off-by: Tyler Hicks <tyhicks@canonical.com>