### PR TITLE
api: Add support for SCMP_ACT_KILL_PROCESS

### DIFF
--- a/doc/man/man3/seccomp_init.3
+++ b/doc/man/man3/seccomp_init.3
@@ -52,6 +52,10 @@ The thread will be terminated by the kernel with SIGSYS when it calls a syscall
 that does not match any of the configured seccomp filter rules.  The thread
 will not be able to catch the signal.
 .TP
+.B SCMP_ACT_KILL_PROCESS
+The entire process will be terminated by the kernel with SIGSYS when it calls a
+syscall that does not match any of the configured seccomp filter rules.
+.TP
 .B SCMP_ACT_TRAP
 The thread will be sent a SIGSYS signal when it calls a syscall that does not
 match any of the configured seccomp filter rules.  It may catch this and change

--- a/doc/man/man3/seccomp_rule_add.3
+++ b/doc/man/man3/seccomp_rule_add.3
@@ -111,6 +111,10 @@ values are as follows:
 The thread will be killed by the kernel when it calls a syscall that matches
 the filter rule.
 .TP
+.B SCMP_ACT_KILL_PROCESS
+The process will be killed by the kernel when it calls a syscall that matches
+the filter rule.
+.TP
 .B SCMP_ACT_TRAP
 The thread will throw a SIGSYS signal when it calls a syscall that matches the
 filter rule.

--- a/include/seccomp.h.in
+++ b/include/seccomp.h.in
@@ -305,7 +305,7 @@ const struct scmp_version *seccomp_version(void);
  *      uses the seccomp(2) syscall instead of the prctl(2) syscall
  *  3 : support for the SCMP_FLTATR_CTL_LOG filter attribute
  *      support for the SCMP_ACT_LOG action
- *  4 : support for the SCMP_ACT_KILL_PROCESS action
+ *      support for the SCMP_ACT_KILL_PROCESS action
  *
  */
 const unsigned int seccomp_api_get(void);

--- a/include/seccomp.h.in
+++ b/include/seccomp.h.in
@@ -305,6 +305,7 @@ const struct scmp_version *seccomp_version(void);
  *      uses the seccomp(2) syscall instead of the prctl(2) syscall
  *  3 : support for the SCMP_FLTATR_CTL_LOG filter attribute
  *      support for the SCMP_ACT_LOG action
+ *  4 : support for the SCMP_ACT_KILL_PROCESS action
  *
  */
 const unsigned int seccomp_api_get(void);

--- a/include/seccomp.h.in
+++ b/include/seccomp.h.in
@@ -244,7 +244,15 @@ struct scmp_arg_cmp {
 /**
  * Kill the process
  */
-#define SCMP_ACT_KILL		0x00000000U
+#define SCMP_ACT_KILL_PROCESS	0x80000000U
+/**
+ * Kill the thread
+ */
+#define SCMP_ACT_KILL_THREAD	0x00000000U
+/**
+ * Kill the thread.  Defined for backward compatibility
+ */
+#define SCMP_ACT_KILL		SCMP_ACT_KILL_THREAD
 /**
  * Throw a SIGSYS signal
  */

--- a/src/api.c
+++ b/src/api.c
@@ -149,13 +149,6 @@ API int seccomp_api_set(unsigned int level)
 		sys_set_seccomp_flag(SECCOMP_FILTER_FLAG_TSYNC, true);
 		sys_set_seccomp_flag(SECCOMP_FILTER_FLAG_LOG, true);
 		sys_set_seccomp_action(SCMP_ACT_LOG, true);
-		sys_set_seccomp_action(SCMP_ACT_KILL_PROCESS, false);
-		break;
-	case 4:
-		sys_set_seccomp_syscall(true);
-		sys_set_seccomp_flag(SECCOMP_FILTER_FLAG_TSYNC, true);
-		sys_set_seccomp_flag(SECCOMP_FILTER_FLAG_LOG, true);
-		sys_set_seccomp_action(SCMP_ACT_LOG, true);
 		sys_set_seccomp_action(SCMP_ACT_KILL_PROCESS, true);
 		break;
 	default:

--- a/src/api.c
+++ b/src/api.c
@@ -135,18 +135,28 @@ API int seccomp_api_set(unsigned int level)
 		sys_set_seccomp_flag(SECCOMP_FILTER_FLAG_TSYNC, false);
 		sys_set_seccomp_flag(SECCOMP_FILTER_FLAG_LOG, false);
 		sys_set_seccomp_action(SCMP_ACT_LOG, false);
+		sys_set_seccomp_action(SCMP_ACT_KILL_PROCESS, false);
 		break;
 	case 2:
 		sys_set_seccomp_syscall(true);
 		sys_set_seccomp_flag(SECCOMP_FILTER_FLAG_TSYNC, true);
 		sys_set_seccomp_flag(SECCOMP_FILTER_FLAG_LOG, false);
 		sys_set_seccomp_action(SCMP_ACT_LOG, false);
+		sys_set_seccomp_action(SCMP_ACT_KILL_PROCESS, false);
 		break;
 	case 3:
 		sys_set_seccomp_syscall(true);
 		sys_set_seccomp_flag(SECCOMP_FILTER_FLAG_TSYNC, true);
 		sys_set_seccomp_flag(SECCOMP_FILTER_FLAG_LOG, true);
 		sys_set_seccomp_action(SCMP_ACT_LOG, true);
+		sys_set_seccomp_action(SCMP_ACT_KILL_PROCESS, false);
+		break;
+	case 4:
+		sys_set_seccomp_syscall(true);
+		sys_set_seccomp_flag(SECCOMP_FILTER_FLAG_TSYNC, true);
+		sys_set_seccomp_flag(SECCOMP_FILTER_FLAG_LOG, true);
+		sys_set_seccomp_action(SCMP_ACT_LOG, true);
+		sys_set_seccomp_action(SCMP_ACT_KILL_PROCESS, true);
 		break;
 	default:
 		return -EINVAL;

--- a/src/gen_pfc.c
+++ b/src/gen_pfc.c
@@ -117,8 +117,11 @@ static void _pfc_arg(FILE *fds,
  */
 static void _pfc_action(FILE *fds, uint32_t action)
 {
-	switch (action & 0xffff0000) {
-	case SCMP_ACT_KILL:
+	switch (action & SECCOMP_RET_ACTION_FULL) {
+	case SCMP_ACT_KILL_PROCESS:
+		fprintf(fds, "action KILL-PROCESS;\n");
+		break;
+	case SCMP_ACT_KILL_THREAD:
 		fprintf(fds, "action KILL;\n");
 		break;
 	case SCMP_ACT_TRAP:

--- a/src/gen_pfc.c
+++ b/src/gen_pfc.c
@@ -35,6 +35,7 @@
 #include "db.h"
 #include "gen_pfc.h"
 #include "helper.h"
+#include "system.h"
 
 struct pfc_sys_list {
 	struct db_sys_list *sys;
@@ -110,10 +111,6 @@ static void _pfc_arg(FILE *fds,
 		fprintf(fds, "$a%d", node->arg);
 }
 
-#ifndef SECCOMP_RET_ACTION_FULL
-#define SECCOMP_RET_ACTION_FULL 0xffff0000U
-#endif
-
 /**
  * Display a string representation of the filter action
  * @param fds the file stream to send the output
@@ -123,7 +120,7 @@ static void _pfc_action(FILE *fds, uint32_t action)
 {
 	switch (action & SECCOMP_RET_ACTION_FULL) {
 	case SCMP_ACT_KILL_PROCESS:
-		fprintf(fds, "action KILL-PROCESS;\n");
+		fprintf(fds, "action KILL_PROCESS;\n");
 		break;
 	case SCMP_ACT_KILL_THREAD:
 		fprintf(fds, "action KILL;\n");

--- a/src/gen_pfc.c
+++ b/src/gen_pfc.c
@@ -110,6 +110,10 @@ static void _pfc_arg(FILE *fds,
 		fprintf(fds, "$a%d", node->arg);
 }
 
+#ifndef SECCOMP_RET_ACTION_FULL
+#define SECCOMP_RET_ACTION_FULL 0xffff0000U
+#endif
+
 /**
  * Display a string representation of the filter action
  * @param fds the file stream to send the output

--- a/src/python/libseccomp.pxd
+++ b/src/python/libseccomp.pxd
@@ -69,6 +69,7 @@ cdef extern from "seccomp.h":
         SCMP_CMP_MASKED_EQ
 
     cdef enum:
+        SCMP_ACT_KILL_PROCESS
         SCMP_ACT_KILL
         SCMP_ACT_TRAP
         SCMP_ACT_LOG

--- a/src/python/seccomp.pyx
+++ b/src/python/seccomp.pyx
@@ -29,7 +29,8 @@ based filtering interface that should be familiar to, and easily adopted
 by application developers.
 
 Filter action values:
-    KILL - kill the process
+    KILL_PROCESS - kill the process
+    KILL - kill the thread
     LOG - allow the syscall to be executed after the action has been logged
     ALLOW - allow the syscall to execute
     TRAP - a SIGSYS signal will be thrown
@@ -94,6 +95,7 @@ def c_str(string):
     else:
         return bytes(string, "ascii")
 
+KILL_PROCESS = libseccomp.SCMP_ACT_KILL_PROCESS
 KILL = libseccomp.SCMP_ACT_KILL
 TRAP = libseccomp.SCMP_ACT_TRAP
 LOG = libseccomp.SCMP_ACT_LOG
@@ -545,7 +547,8 @@ cdef class SyscallFilter:
         """ Add a new rule to filter.
 
         Arguments:
-        action - the rule action: KILL, TRAP, ERRNO(), TRACE(), LOG, or ALLOW
+        action - the rule action: KILL_PROCESS, KILL, TRAP, ERRNO(), TRACE(),
+                 LOG, or ALLOW
         syscall - the syscall name or number
         args - variable number of Arg objects
 
@@ -627,7 +630,8 @@ cdef class SyscallFilter:
         """ Add a new rule to filter.
 
         Arguments:
-        action - the rule action: KILL, TRAP, ERRNO(), TRACE(), LOG, or ALLOW
+        action - the rule action: KILL_PROCESS, KILL, TRAP, ERRNO(), TRACE(),
+                 LOG, or ALLOW
         syscall - the syscall name or number
         args - variable number of Arg objects
 

--- a/src/system.c
+++ b/src/system.c
@@ -124,8 +124,10 @@ void sys_set_seccomp_syscall(bool enable)
 int sys_chk_seccomp_action(uint32_t action)
 {
 	int rc, nr_seccomp;
-	uint32_t kaction = action & SECCOMP_RET_ACTION_FULL;
 
+/* SECCOMP_RET_ACTION_FULL was defined in kernel v4.14 */
+#ifdef SECCOMP_RET_ACTION_FULL
+	uint32_t kaction = action & SECCOMP_RET_ACTION_FULL;
 
 	nr_seccomp = arch_syscall_resolve_name(arch_def_native, "seccomp");
 	if (nr_seccomp != __NR_SCMP_ERROR) {
@@ -139,6 +141,7 @@ int sys_chk_seccomp_action(uint32_t action)
 		else if (rc < 0)
 			return 0;
 	}
+#endif
 
 	if (action == SCMP_ACT_KILL_PROCESS) {
 		return 1;

--- a/src/system.h
+++ b/src/system.h
@@ -37,13 +37,6 @@ struct db_filter_col;
 /* system header file */
 #include <linux/seccomp.h>
 
-/* SECCOMP_RET_ACTION_FULL was added in kernel v4.14.  It may not be
- * defined on older kernels
- */
-#ifndef SECCOMP_RET_ACTION_FULL
-#define SECCOMP_RET_ACTION_FULL 0xffff0000U
-#endif
-
 #else
 
 /* NOTE: the definitions below were taken from the Linux Kernel sources */
@@ -126,6 +119,13 @@ typedef struct sock_filter bpf_instr_raw;
 
 #ifndef SECCOMP_RET_LOG
 #define SECCOMP_RET_LOG		0x7ffc0000U /* allow after logging */
+#endif
+
+/* SECCOMP_RET_ACTION_FULL was added in kernel v4.14.  It may not be
+ * defined on older kernels
+ */
+#ifndef SECCOMP_RET_ACTION_FULL
+#define SECCOMP_RET_ACTION_FULL 0xffff0000U
 #endif
 
 int sys_chk_seccomp_syscall(void);

--- a/src/system.h
+++ b/src/system.h
@@ -55,13 +55,16 @@ struct db_filter_col;
  * The ordering ensures that a min_t() over composed return values always
  * selects the least permissive choice.
  */
-#define SECCOMP_RET_KILL	0x00000000U /* kill the task immediately */
+#define SECCOMP_RET_KILL_PROCESS 0x80000000U /* kill the process immediately */
+#define SECCOMP_RET_KILL_THREAD	0x00000000U /* kill the thread immediately */
+#define SECCOMP_RET_KILL	SECCOMP_RET_KILL_THREAD /* default to killing the thread */
 #define SECCOMP_RET_TRAP	0x00030000U /* disallow and force a SIGSYS */
 #define SECCOMP_RET_ERRNO	0x00050000U /* returns an errno */
 #define SECCOMP_RET_TRACE	0x7ff00000U /* pass to a tracer or disallow */
 #define SECCOMP_RET_ALLOW	0x7fff0000U /* allow */
 
 /* Masks for the return value sections. */
+#define SECCOMP_RET_ACTION_FULL 0xffff0000U
 #define SECCOMP_RET_ACTION	0x7fff0000U
 #define SECCOMP_RET_DATA	0x0000ffffU
 

--- a/src/system.h
+++ b/src/system.h
@@ -37,6 +37,13 @@ struct db_filter_col;
 /* system header file */
 #include <linux/seccomp.h>
 
+/* SECCOMP_RET_ACTION_FULL was added in kernel v4.14.  It may not be
+ * defined on older kernels
+ */
+#ifndef SECCOMP_RET_ACTION_FULL
+#define SECCOMP_RET_ACTION_FULL 0xffff0000U
+#endif
+
 #else
 
 /* NOTE: the definitions below were taken from the Linux Kernel sources */

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -49,3 +49,4 @@ util.pyc
 41-sim-syscall_priority_arch
 42-sim-adv_chains
 43-sim-kill_process
+44-live-kill_process

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -48,3 +48,4 @@ util.pyc
 40-sim-log
 41-sim-syscall_priority_arch
 42-sim-adv_chains
+43-sim-kill_process

--- a/tests/06-sim-actions.c
+++ b/tests/06-sim-actions.c
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
 	if (rc < 0)
 		goto out;
 
-	rc = seccomp_api_set(4);
+	rc = seccomp_api_set(3);
 	if (rc != 0)
 		return EOPNOTSUPP;
 

--- a/tests/06-sim-actions.c
+++ b/tests/06-sim-actions.c
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
 	if (rc < 0)
 		goto out;
 
-	rc = seccomp_api_set(3);
+	rc = seccomp_api_set(4);
 	if (rc != 0)
 		return EOPNOTSUPP;
 
@@ -61,6 +61,10 @@ int main(int argc, char *argv[])
 		goto out;
 
 	rc = seccomp_rule_add(ctx, SCMP_ACT_TRACE(1234), SCMP_SYS(open), 0);
+	if (rc != 0)
+		goto out;
+
+	rc = seccomp_rule_add(ctx, SCMP_ACT_KILL_PROCESS, SCMP_SYS(stat), 0);
 	if (rc != 0)
 		goto out;
 

--- a/tests/06-sim-actions.py
+++ b/tests/06-sim-actions.py
@@ -30,7 +30,7 @@ import util
 from seccomp import *
 
 def test(args):
-    set_api(4)
+    set_api(3)
 
     f = SyscallFilter(KILL)
     f.add_rule(ALLOW, "read")

--- a/tests/06-sim-actions.tests
+++ b/tests/06-sim-actions.tests
@@ -12,11 +12,12 @@ test type: bpf-sim
 06-sim-actions	all		write		1		0x856B008	N	N	N	N	ERRNO(1)
 06-sim-actions	all		close		4		N		N	N	N	N	TRAP
 06-sim-actions	all,-aarch64	open		0x856B008	4		N	N	N	N	TRACE(1234)
+06-sim-actions	all		stat		N		N		N	N	N	N	KILL_PROCESS
 06-sim-actions	all		rt_sigreturn	N		N		N	N	N	N	LOG
 06-sim-actions	x86		0-2		N		N		N	N	N	N	KILL
 06-sim-actions	x86		7-172		N		N		N	N	N	N	KILL
 06-sim-actions	x86		174-350		N		N		N	N	N	N	KILL
-06-sim-actions	x86_64		4-14		N		N		N	N	N	N	KILL
+06-sim-actions	x86_64		5-14		N		N		N	N	N	N	KILL
 06-sim-actions	x86_64		16-350		N		N		N	N	N	N	KILL
 
 test type: bpf-sim-fuzz

--- a/tests/38-basic-pfc_coverage.c
+++ b/tests/38-basic-pfc_coverage.c
@@ -38,6 +38,10 @@ int main(int argc, char *argv[])
 	/* stdout */
 	fd = 1;
 
+	rc = seccomp_api_set(4);
+	if (rc != 0)
+		return EOPNOTSUPP;
+
 	ctx = seccomp_init(SCMP_ACT_ALLOW);
 	if (ctx == NULL) {
 		rc = ENOMEM;

--- a/tests/38-basic-pfc_coverage.c
+++ b/tests/38-basic-pfc_coverage.c
@@ -80,6 +80,9 @@ int main(int argc, char *argv[])
 	rc = seccomp_rule_add(ctx, SCMP_ACT_TRACE(1), SCMP_SYS(exit), 0);
 	if (rc < 0)
 		goto out;
+	rc = seccomp_rule_add(ctx, SCMP_ACT_KILL_PROCESS, SCMP_SYS(fstat), 0);
+	if (rc < 0)
+		goto out;
 
 	rc = seccomp_export_pfc(ctx, fd);
 	if (rc < 0)

--- a/tests/38-basic-pfc_coverage.c
+++ b/tests/38-basic-pfc_coverage.c
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
 	/* stdout */
 	fd = 1;
 
-	rc = seccomp_api_set(4);
+	rc = seccomp_api_set(3);
 	if (rc != 0)
 		return EOPNOTSUPP;
 

--- a/tests/38-basic-pfc_coverage.pfc
+++ b/tests/38-basic-pfc_coverage.pfc
@@ -8,7 +8,7 @@ if ($arch == 3221225534)
     action TRACE(1);
   # filter for syscall "fstat" (5) [priority: 65535]
   if ($syscall == 5)
-    action KILL-PROCESS;
+    action KILL_PROCESS;
   # filter for syscall "close" (3) [priority: 65535]
   if ($syscall == 3)
     action ERRNO(1);
@@ -70,7 +70,7 @@ if ($arch == 3221225534)
 if ($arch == 1073741827)
   # filter for syscall "fstat" (108) [priority: 65535]
   if ($syscall == 108)
-    action KILL-PROCESS;
+    action KILL_PROCESS;
   # filter for syscall "close" (6) [priority: 65535]
   if ($syscall == 6)
     action ERRNO(1);

--- a/tests/38-basic-pfc_coverage.pfc
+++ b/tests/38-basic-pfc_coverage.pfc
@@ -6,6 +6,9 @@ if ($arch == 3221225534)
   # filter for syscall "exit" (60) [priority: 65535]
   if ($syscall == 60)
     action TRACE(1);
+  # filter for syscall "fstat" (5) [priority: 65535]
+  if ($syscall == 5)
+    action KILL-PROCESS;
   # filter for syscall "close" (3) [priority: 65535]
   if ($syscall == 3)
     action ERRNO(1);
@@ -65,6 +68,9 @@ if ($arch == 3221225534)
   action ALLOW;
 # filter for arch x86 (1073741827)
 if ($arch == 1073741827)
+  # filter for syscall "fstat" (108) [priority: 65535]
+  if ($syscall == 108)
+    action KILL-PROCESS;
   # filter for syscall "close" (6) [priority: 65535]
   if ($syscall == 6)
     action ERRNO(1);

--- a/tests/43-sim-kill_process.c
+++ b/tests/43-sim-kill_process.c
@@ -36,10 +36,6 @@ int main(int argc, char *argv[])
 	if (rc < 0)
 		goto out;
 
-	rc = seccomp_api_set(4);
-	if (rc != 0)
-		return EOPNOTSUPP;
-
 	ctx = seccomp_init(SCMP_ACT_KILL_PROCESS);
 	if (ctx == NULL)
 		return ENOMEM;

--- a/tests/43-sim-kill_process.c
+++ b/tests/43-sim-kill_process.c
@@ -36,6 +36,10 @@ int main(int argc, char *argv[])
 	if (rc < 0)
 		goto out;
 
+	rc = seccomp_api_set(4);
+	if (rc != 0)
+		return EOPNOTSUPP;
+
 	ctx = seccomp_init(SCMP_ACT_KILL_PROCESS);
 	if (ctx == NULL)
 		return ENOMEM;

--- a/tests/43-sim-kill_process.c
+++ b/tests/43-sim-kill_process.c
@@ -59,6 +59,11 @@ int main(int argc, char *argv[])
 	if (rc != 0)
 		goto out;
 
+	rc = seccomp_rule_add(ctx, SCMP_ACT_ERRNO(6), SCMP_SYS(close), 1,
+			      SCMP_A0(SCMP_CMP_GT, 100));
+	if (rc != 0)
+		goto out;
+
 	rc = util_filter_output(&opts, ctx);
 	if (rc)
 		goto out;

--- a/tests/43-sim-kill_process.c
+++ b/tests/43-sim-kill_process.c
@@ -1,0 +1,69 @@
+/**
+ * Seccomp Library test program
+ *
+ * Copyright (c) 2018 Oracle and/or its affiliates.  All rights reserved.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include <errno.h>
+#include <unistd.h>
+
+#include <seccomp.h>
+
+#include "util.h"
+
+int main(int argc, char *argv[])
+{
+	int rc;
+	struct util_options opts;
+	scmp_filter_ctx ctx = NULL;
+
+	rc = util_getopt(argc, argv, &opts);
+	if (rc < 0)
+		goto out;
+
+	ctx = seccomp_init(SCMP_ACT_KILL_PROCESS);
+	if (ctx == NULL)
+		return ENOMEM;
+
+	rc = seccomp_arch_remove(ctx, SCMP_ARCH_NATIVE);
+	if (rc != 0)
+		goto out;
+	rc = seccomp_arch_add(ctx, SCMP_ARCH_X86_64);
+	if (rc != 0)
+		goto out;
+
+	rc = seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(read), 0);
+	if (rc != 0)
+		goto out;
+
+	rc = seccomp_rule_add(ctx, SCMP_ACT_ERRNO(5), SCMP_SYS(write), 0);
+	if (rc != 0)
+		goto out;
+
+	rc = seccomp_rule_add(ctx, SCMP_ACT_KILL_THREAD, SCMP_SYS(open), 0);
+	if (rc != 0)
+		goto out;
+
+	rc = util_filter_output(&opts, ctx);
+	if (rc)
+		goto out;
+
+out:
+	seccomp_release(ctx);
+	return (rc < 0 ? -rc : rc);
+}

--- a/tests/43-sim-kill_process.py
+++ b/tests/43-sim-kill_process.py
@@ -35,6 +35,7 @@ def test(args):
     f.add_rule_exactly(ALLOW, "read")
     f.add_rule_exactly(ERRNO(5), "write")
     f.add_rule_exactly(KILL, "open")
+    f.add_rule_exactly(ERRNO(6), "close", Arg(0, GT, 100))
     return f
 
 args = util.get_opt()

--- a/tests/43-sim-kill_process.py
+++ b/tests/43-sim-kill_process.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+#
+# Seccomp Library test program
+#
+# Copyright (c) 2018 Oracle and/or its affiliates.  All rights reserved.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+import argparse
+import sys
+
+import util
+
+from seccomp import *
+
+def test(args):
+    f = SyscallFilter(KILL_PROCESS)
+    f.remove_arch(Arch())
+    f.add_arch(Arch("x86_64"))
+    f.add_rule_exactly(ALLOW, "read")
+    f.add_rule_exactly(ERRNO(5), "write")
+    f.add_rule_exactly(KILL, "open")
+    return f
+
+args = util.get_opt()
+ctx = test(args)
+util.filter_output(args, ctx)
+
+# kate: syntax python;
+# kate: indent-mode python; space-indent on; indent-width 4; mixedindent off;

--- a/tests/43-sim-kill_process.tests
+++ b/tests/43-sim-kill_process.tests
@@ -13,7 +13,5 @@ test type: bpf-sim
 43-sim-kill_process	+x86_64	2		N	N	N	N	N	N	KILL
 43-sim-kill_process	+x86_64	3		N	N	N	N	N	N	KILL_PROCESS
 
-test type: bpf-valgrind
-
 # Testname
 43-sim-kill_process

--- a/tests/43-sim-kill_process.tests
+++ b/tests/43-sim-kill_process.tests
@@ -11,7 +11,7 @@ test type: bpf-sim
 43-sim-kill_process	+x86_64	0		N	N	N	N	N	N	ALLOW
 43-sim-kill_process	+x86_64	1		N	N	N	N	N	N	ERRNO(5)
 43-sim-kill_process	+x86_64	2		N	N	N	N	N	N	KILL
-43-sim-kill_process	+x86_64	3		N	N	N	N	N	N	KILL_PROCESS
+43-sim-kill_process	+x86_64	3		100	N	N	N	N	N	KILL_PROCESS
+43-sim-kill_process	+x86_64	3		101	N	N	N	N	N	ERRNO(6)
+43-sim-kill_process	+x86_64	4		N	N	N	N	N	N	KILL_PROCESS
 
-# Testname
-43-sim-kill_process

--- a/tests/43-sim-kill_process.tests
+++ b/tests/43-sim-kill_process.tests
@@ -1,0 +1,19 @@
+#
+# libseccomp regression test automation data
+#
+# Copyright (c) 2018 Oracle and/or its affiliates.  All rights reserved.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+test type: bpf-sim
+
+# Testname		Arch	Syscall		Arg0	Arg1	Arg2	Arg3	Arg4	Arg5	Result
+43-sim-kill_process	+x86_64	0		N	N	N	N	N	N	ALLOW
+43-sim-kill_process	+x86_64	1		N	N	N	N	N	N	ERRNO(5)
+43-sim-kill_process	+x86_64	2		N	N	N	N	N	N	KILL
+43-sim-kill_process	+x86_64	3		N	N	N	N	N	N	KILL-PROCESS
+
+test type: bpf-valgrind
+
+# Testname
+43-sim-kill_process

--- a/tests/43-sim-kill_process.tests
+++ b/tests/43-sim-kill_process.tests
@@ -11,7 +11,7 @@ test type: bpf-sim
 43-sim-kill_process	+x86_64	0		N	N	N	N	N	N	ALLOW
 43-sim-kill_process	+x86_64	1		N	N	N	N	N	N	ERRNO(5)
 43-sim-kill_process	+x86_64	2		N	N	N	N	N	N	KILL
-43-sim-kill_process	+x86_64	3		N	N	N	N	N	N	KILL-PROCESS
+43-sim-kill_process	+x86_64	3		N	N	N	N	N	N	KILL_PROCESS
 
 test type: bpf-valgrind
 

--- a/tests/44-live-kill_process.c
+++ b/tests/44-live-kill_process.c
@@ -1,0 +1,105 @@
+/**
+ * Seccomp Library test program
+ *
+ * Copyright (c) 2018 Oracle and/or its affiliates.  All rights reserved.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <seccomp.h>
+
+#include "util.h"
+
+
+static const unsigned int whitelist[] = {
+	SCMP_SYS(clone),
+	SCMP_SYS(exit),
+	SCMP_SYS(exit_group),
+	SCMP_SYS(futex),
+	SCMP_SYS(madvise),
+	SCMP_SYS(mmap),
+	SCMP_SYS(mprotect),
+	SCMP_SYS(munmap),
+	SCMP_SYS(nanosleep),
+	SCMP_SYS(set_robust_list),
+};
+
+/**
+ * Child thread created via pthread_create()
+ *
+ * This thread will call a disallowed syscall.  It should
+ * cause the entire program to die (and not just this
+ * thread.)
+ */
+void *child_start(void *param)
+{
+	int fd, *i = (int *)param;
+
+	*i = 1;
+
+	/* make a disallowed syscall */
+	fd = open("/dev/null", O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR);
+	/* we should never get here.  seccomp should kill the entire
+	 * process when open() is called.
+	  */
+	if (fd < 0)
+		*i = fd;
+
+	return NULL;
+}
+
+int main(int argc, char *argv[])
+{
+	int rc, i, param = 0;
+	scmp_filter_ctx ctx = NULL;
+	pthread_t child_thread;
+
+	ctx = seccomp_init(SCMP_ACT_KILL_PROCESS);
+	if (ctx == NULL)
+		return ENOMEM;
+
+	for (i = 0; i < sizeof(whitelist) / sizeof(whitelist[0]); i++) {
+		rc = seccomp_rule_add(ctx, SCMP_ACT_ALLOW, whitelist[i], 0);
+		if (rc != 0)
+			goto out;
+	}
+
+	rc = seccomp_load(ctx);
+	if (rc != 0)
+		goto out;
+
+	rc = pthread_create(&child_thread, NULL, child_start, &param);
+	if (rc != 0)
+		goto out;
+
+	/* sleep for a bit to ensure that the child thread has time to run */
+	sleep(1);
+
+	/* we should never get here! */
+	rc = -EACCES;
+	goto out;
+
+out:
+	seccomp_release(ctx);
+	return (rc < 0 ? -rc : rc);
+}

--- a/tests/44-live-kill_process.tests
+++ b/tests/44-live-kill_process.tests
@@ -1,0 +1,11 @@
+#
+# libseccomp regression test automation data
+#
+# Copyright (c) 2018 Oracle and/or its affiliates.  All rights reserved.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+test type: live
+
+# Testname		Result
+44-live-kill_process	KILL_PROCESS

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -26,7 +26,7 @@ else
 DBG_STATIC = -static
 endif
 
-AM_LDFLAGS = ${DBG_STATIC}
+AM_LDFLAGS = ${DBG_STATIC} -lpthread
 
 LDADD = util.la ../src/libseccomp.la ${CODE_COVERAGE_LIBS}
 
@@ -82,7 +82,8 @@ check_PROGRAMS = \
 	40-sim-log \
 	41-sim-syscall_priority_arch \
 	42-sim-adv_chains \
-	43-sim-kill_process
+	43-sim-kill_process \
+	44-live-kill_process
 
 EXTRA_DIST_TESTPYTHON = \
 	util.py \
@@ -126,7 +127,8 @@ EXTRA_DIST_TESTPYTHON = \
 	40-sim-log.py \
 	41-sim-syscall_priority_arch.py \
 	42-sim-adv_chains.py \
-	43-sim-kill_process.py
+	43-sim-kill_process.py \
+	44-live-kill_process.py
 
 EXTRA_DIST_TESTCFGS = \
 	01-sim-allow.tests \
@@ -171,7 +173,8 @@ EXTRA_DIST_TESTCFGS = \
 	40-sim-log.tests \
 	41-sim-syscall_priority_arch.tests \
 	42-sim-adv_chains.tests \
-	43-sim-kill_process.tests
+	43-sim-kill_process.tests \
+	44-live-kill_process.tests
 
 EXTRA_DIST_TESTSCRIPTS = \
 	38-basic-pfc_coverage.sh 38-basic-pfc_coverage.pfc

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -81,7 +81,8 @@ check_PROGRAMS = \
 	39-basic-api_level \
 	40-sim-log \
 	41-sim-syscall_priority_arch \
-	42-sim-adv_chains
+	42-sim-adv_chains \
+	43-sim-kill_process
 
 EXTRA_DIST_TESTPYTHON = \
 	util.py \
@@ -124,7 +125,8 @@ EXTRA_DIST_TESTPYTHON = \
 	37-sim-ipc_syscalls_be.py \
 	40-sim-log.py \
 	41-sim-syscall_priority_arch.py \
-	42-sim-adv_chains.py
+	42-sim-adv_chains.py \
+	43-sim-kill_process.py
 
 EXTRA_DIST_TESTCFGS = \
 	01-sim-allow.tests \
@@ -168,7 +170,8 @@ EXTRA_DIST_TESTCFGS = \
 	39-basic-api_level.tests \
 	40-sim-log.tests \
 	41-sim-syscall_priority_arch.tests \
-	42-sim-adv_chains.tests
+	42-sim-adv_chains.tests \
+	43-sim-kill_process.tests
 
 EXTRA_DIST_TESTSCRIPTS = \
 	38-basic-pfc_coverage.sh 38-basic-pfc_coverage.pfc

--- a/tests/regression
+++ b/tests/regression
@@ -724,6 +724,7 @@ function run_test_live() {
 	# setup the arch specific return values
 	case "$arch" in
 	x86|x86_64|x32|arm|aarch64|parisc|parisc64|ppc|ppc64|ppc64le|ppc|s390|s390x)
+		rc_kill_process=159
 		rc_kill=159
 		rc_allow=160
 		rc_trap=161
@@ -732,6 +733,7 @@ function run_test_live() {
 		rc_log=164
 		;;
 	mips|mipsel|mips64|mips64n32|mipsel64|mipsel64n32)
+		rc_kill_process=140
 		rc_kill=140
 		rc_allow=160
 		rc_trap=161
@@ -747,7 +749,10 @@ function run_test_live() {
 	esac
 
 	# verify the results
-	if [[ $line_act == "KILL" && $rc -eq $rc_kill ]]; then
+	if [[ $line_act == "KILL_PROCESS" && $rc -eq $rc_kill_process ]]; then
+		print_result $1 "SUCCESS" ""
+		stats_success=$(($stats_success+1))
+	elif [[ $line_act == "KILL" && $rc -eq $rc_kill ]]; then
 		print_result $1 "SUCCESS" ""
 		stats_success=$(($stats_success+1))
 	elif [[ $line_act == "ALLOW" && $rc -eq $rc_allow ]]; then

--- a/tests/util.c
+++ b/tests/util.c
@@ -168,6 +168,8 @@ int util_action_parse(const char *action)
 
 	if (strcasecmp(action, "KILL") == 0)
 		return SCMP_ACT_KILL;
+	if (strcasecmp(action, "KILL_PROCESS") == 0)
+		return SCMP_ACT_KILL_PROCESS;
 	else if (strcasecmp(action, "TRAP") == 0)
 		return SCMP_ACT_TRAP;
 	else if (strcasecmp(action, "ERRNO") == 0)

--- a/tools/bpf.h
+++ b/tools/bpf.h
@@ -56,11 +56,14 @@ struct sock_filter {
 typedef struct sock_filter bpf_instr_raw;
 
 /* seccomp return masks */
+#define SECCOMP_RET_ACTION_FULL 0xffff0000U
 #define SECCOMP_RET_ACTION	0x7fff0000U
 #define SECCOMP_RET_DATA	0x0000ffffU
 
 /* seccomp action values */
-#define SECCOMP_RET_KILL	0x00000000U
+#define SECCOMP_RET_KILL_PROCESS 0x80000000U
+#define SECCOMP_RET_KILL_THREAD 0x00000000U
+#define SECCOMP_RET_KILL	SECCOMP_RET_KILL_THREAD
 #define SECCOMP_RET_TRAP	0x00030000U
 #define SECCOMP_RET_ERRNO	0x00050000U
 #define SECCOMP_RET_TRACE	0x7ff00000U

--- a/tools/scmp_bpf_disasm.c
+++ b/tools/scmp_bpf_disasm.c
@@ -173,11 +173,14 @@ static const char *bpf_decode_op(const bpf_instr_raw *bpf)
  */
 static void bpf_decode_action(uint32_t k)
 {
-	uint32_t act = k & SECCOMP_RET_ACTION;
+	uint32_t act = k & SECCOMP_RET_ACTION_FULL;
 	uint32_t data = k & SECCOMP_RET_DATA;
 
 	switch (act) {
-	case SECCOMP_RET_KILL:
+	case SECCOMP_RET_KILL_PROCESS:
+		printf("KILL-PROCESS");
+		break;
+	case SECCOMP_RET_KILL_THREAD:
 		printf("KILL");
 		break;
 	case SECCOMP_RET_TRAP:

--- a/tools/scmp_bpf_disasm.c
+++ b/tools/scmp_bpf_disasm.c
@@ -178,7 +178,7 @@ static void bpf_decode_action(uint32_t k)
 
 	switch (act) {
 	case SECCOMP_RET_KILL_PROCESS:
-		printf("KILL-PROCESS");
+		printf("KILL_PROCESS");
 		break;
 	case SECCOMP_RET_KILL_THREAD:
 		printf("KILL");

--- a/tools/scmp_bpf_sim.c
+++ b/tools/scmp_bpf_sim.c
@@ -117,7 +117,7 @@ static void end_action(uint32_t action, unsigned int line)
 
 	switch (act) {
 	case SECCOMP_RET_KILL_PROCESS:
-		fprintf(stdout, "KILL-PROCESS\n");
+		fprintf(stdout, "KILL_PROCESS\n");
 		break;
 	case SECCOMP_RET_KILL_THREAD:
 		fprintf(stdout, "KILL\n");

--- a/tools/scmp_bpf_sim.c
+++ b/tools/scmp_bpf_sim.c
@@ -112,11 +112,14 @@ static void exit_error(unsigned int rc, unsigned int line)
  */
 static void end_action(uint32_t action, unsigned int line)
 {
-	uint32_t act = action & SECCOMP_RET_ACTION;
+	uint32_t act = action & SECCOMP_RET_ACTION_FULL;
 	uint32_t data = action & SECCOMP_RET_DATA;
 
 	switch (act) {
-	case SECCOMP_RET_KILL:
+	case SECCOMP_RET_KILL_PROCESS:
+		fprintf(stdout, "KILL-PROCESS\n");
+		break;
+	case SECCOMP_RET_KILL_THREAD:
 		fprintf(stdout, "KILL\n");
 		break;
 	case SECCOMP_RET_TRAP:


### PR DESCRIPTION
This patch addresses issue 96 - "RFE: add support for SECCOMP_RET_KILL_PROCESS" and issue 93 - "BUG: compatibility with openmp".

Test results w/ code coverage:

```./configure --enable-code-coverage
make check-code-coverage

Regression Test Summary
tests run: 7895 
tests skipped: 38
tests passed: 7895 
tests failed: 0
tests errored: 0
============================================================
PASS: regression

Line Coverage
91.0%
2160 / 2374 
(prior to these changes, code coverage was 2153 / 2367)

Functions
90.3%
140 / 155


Test results w/ python enabled:

./configure --enable-python
make check

Regression Test Summary
 tests run: 15756
 tests skipped: 110
 tests passed: 15756
 tests failed: 0
 tests errored: 0
============================================================
PASS: regression
```