### PR TITLE
BUG: remove static linking of tools

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -35,8 +35,6 @@ scmp_bpf_disasm_SOURCES = scmp_bpf_disasm.c bpf.h util.h
 scmp_bpf_sim_SOURCES = scmp_bpf_sim.c bpf.h util.h
 
 scmp_sys_resolver_LDADD = ../src/libseccomp.la
-scmp_sys_resolver_LDFLAGS = -static
 scmp_arch_detect_LDADD = ../src/libseccomp.la
-scmp_arch_detect_LDFLAGS = -static
 scmp_bpf_disasm_LDADD = util.la
 scmp_bpf_sim_LDADD = util.la


### PR DESCRIPTION
Do not force static link of tools, it breaks build with:
BR2_SHARED_LIBS=y

Patch retrieved from
https://git.buildroot.net/buildroot/tree/package/libseccomp/0001-remove-static.patch and slighly updated to work with 2.3.3

Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>