### PR TITLE
RFE: refactor bpf duplicate sorting code

### DIFF
--- a/src/gen_bpf.c
+++ b/src/gen_bpf.c
@@ -1209,6 +1209,71 @@ static struct bpf_blk *_gen_bpf_syscall(struct bpf_state *state,
 }
 
 /**
+ * Sort the syscalls
+ * @param syscalls the linked list of syscalls to be sorted
+ * @param s_head the head of the linked list to be returned to the caller
+ * @param s_tail the tail of the linked list to be returned to the caller
+ *
+ * Sorts syscalls by their priority
+ *
+ */
+static void _sort_syscalls_by_priority(struct db_sys_list *syscalls,
+				       struct db_sys_list **s_head,
+				       struct db_sys_list **s_tail)
+{
+	struct db_sys_list *s_iter, *s_iter_b;
+
+	db_list_foreach(s_iter, syscalls) {
+		if (*s_head != NULL) {
+			s_iter_b = *s_head;
+			while ((s_iter_b->pri_nxt != NULL) &&
+			       (s_iter->priority <= s_iter_b->priority))
+				s_iter_b = s_iter_b->pri_nxt;
+
+			if (s_iter->priority > s_iter_b->priority) {
+				s_iter->pri_prv = s_iter_b->pri_prv;
+				s_iter->pri_nxt = s_iter_b;
+				if (s_iter_b == *s_head) {
+					(*s_head)->pri_prv = s_iter;
+					*s_head = s_iter;
+				} else {
+					s_iter->pri_prv->pri_nxt = s_iter;
+					s_iter->pri_nxt->pri_prv = s_iter;
+				}
+			} else {
+				s_iter->pri_prv = *s_tail;
+				s_iter->pri_nxt = NULL;
+				s_iter->pri_prv->pri_nxt = s_iter;
+				*s_tail = s_iter;
+			}
+		} else {
+			*s_head = s_iter;
+			*s_tail = s_iter;
+			(*s_head)->pri_prv = NULL;
+			(*s_head)->pri_nxt = NULL;
+		}
+	}
+}
+
+/**
+ * Sort the syscalls
+ * @param syscalls the linked list of syscalls to be sorted
+ * @param s_head the head of the linked list to be returned to the caller
+ * @param s_tail the tail of the linked list to be returned to the caller
+ *
+ * Wrapper function for sorting syscalls.  Currently only supports
+ * sorting by priority, but may be expanded in the future to sort
+ * by other methods, e.g. num.
+ *
+ */
+static void _sort_syscalls(struct db_sys_list *syscalls,
+			   struct db_sys_list **s_head,
+			   struct db_sys_list **s_tail)
+{
+	_sort_syscalls_by_priority(syscalls, s_head, s_tail);
+}
+
+/**
  * Generate the BPF instruction blocks for a given filter/architecture
  * @param state the BPF state
  * @param db the filter DB
@@ -1228,76 +1293,14 @@ static struct bpf_blk *_gen_bpf_arch(struct bpf_state *state,
 	unsigned int blk_cnt = 0;
 	bool acc_reset;
 	struct bpf_instr instr;
-	struct db_sys_list *s_head = NULL, *s_tail = NULL, *s_iter, *s_iter_b;
+	struct db_sys_list *s_head = NULL, *s_tail = NULL, *s_iter;
 	struct bpf_blk *b_head = NULL, *b_tail = NULL, *b_iter, *b_new;
 
 	state->arch = db->arch;
 
-	/* sort the syscall list */
-	db_list_foreach(s_iter, db->syscalls) {
-		if (s_head != NULL) {
-			s_iter_b = s_head;
-			while ((s_iter_b->pri_nxt != NULL) &&
-			       (s_iter->priority <= s_iter_b->priority))
-				s_iter_b = s_iter_b->pri_nxt;
-
-			if (s_iter->priority > s_iter_b->priority) {
-				s_iter->pri_prv = s_iter_b->pri_prv;
-				s_iter->pri_nxt = s_iter_b;
-				if (s_iter_b == s_head) {
-					s_head->pri_prv = s_iter;
-					s_head = s_iter;
-				} else {
-					s_iter->pri_prv->pri_nxt = s_iter;
-					s_iter->pri_nxt->pri_prv = s_iter;
-				}
-			} else {
-				s_iter->pri_prv = s_tail;
-				s_iter->pri_nxt = NULL;
-				s_iter->pri_prv->pri_nxt = s_iter;
-				s_tail = s_iter;
-			}
-		} else {
-			s_head = s_iter;
-			s_tail = s_iter;
-			s_head->pri_prv = NULL;
-			s_head->pri_nxt = NULL;
-		}
-	}
-	if (db_secondary != NULL) {
-		db_list_foreach(s_iter, db_secondary->syscalls) {
-			if (s_head != NULL) {
-				s_iter_b = s_head;
-				while ((s_iter_b->pri_nxt != NULL) &&
-				       (s_iter->priority <= s_iter_b->priority))
-					s_iter_b = s_iter_b->pri_nxt;
-
-				if (s_iter->priority > s_iter_b->priority) {
-					s_iter->pri_prv = s_iter_b->pri_prv;
-					s_iter->pri_nxt = s_iter_b;
-					if (s_iter_b == s_head) {
-						s_head->pri_prv = s_iter;
-						s_head = s_iter;
-					} else {
-						s_iter->pri_prv->pri_nxt =
-							s_iter;
-						s_iter->pri_nxt->pri_prv =
-							s_iter;
-					}
-				} else {
-					s_iter->pri_prv = s_tail;
-					s_iter->pri_nxt = NULL;
-					s_iter->pri_prv->pri_nxt = s_iter;
-					s_tail = s_iter;
-				}
-			} else {
-				s_head = s_iter;
-				s_tail = s_iter;
-				s_head->pri_prv = NULL;
-				s_head->pri_nxt = NULL;
-			}
-		}
-	}
+	_sort_syscalls(db->syscalls, &s_head, &s_tail);
+	if (db_secondary != NULL)
+		_sort_syscalls(db_secondary->syscalls, &s_head, &s_tail);
 
 	if ((state->arch->token == SCMP_ARCH_X86_64 ||
 	     state->arch->token == SCMP_ARCH_X32) && (db_secondary == NULL))


### PR DESCRIPTION
In _gen_bpf_arch(), there was an identical block of code to sort
the primary database syscalls and the secondary database
syscalls.  This commit refactors those duplicated, inline loops
into a single function.

Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>