### PR TITLE
pfc: fix PFC export hang on prioritized syscall with no rules (GH issue #117)

### DIFF
--- a/src/gen_pfc.c
+++ b/src/gen_pfc.c
@@ -304,8 +304,10 @@ static int _gen_pfc_arch(const struct db_filter_col *col,
 	fprintf(fds, "if ($arch == %u)\n", db->arch->token_bpf);
 	p_iter = p_head;
 	while (p_iter != NULL) {
-		if (!p_iter->sys->valid)
+		if (!p_iter->sys->valid) {
+			p_iter = p_iter->next;
 			continue;
+		}
 		_gen_pfc_syscall(db->arch, p_iter->sys, fds);
 		p_iter = p_iter->next;
 	}

--- a/tests/38-basic-pfc_coverage.c
+++ b/tests/38-basic-pfc_coverage.c
@@ -81,6 +81,12 @@ int main(int argc, char *argv[])
 	if (rc < 0)
 		goto out;
 
+	/* bug #117 - seccomp_export_pfc hangs on prioritized syscalls
+	 * with no rules */
+	rc = seccomp_syscall_priority(ctx, SCMP_SYS(poll), 255);
+	if (rc < 0)
+		goto out;
+
 	rc = seccomp_export_pfc(ctx, fd);
 	if (rc < 0)
 		goto out;


### PR DESCRIPTION
github user @varqox reported that generating PFC will hang if the
libseccomp filter contains a syscalle with a priority but no rule
set.  The root cause is the while() loop in gen_pfc.c that walks
through the filter's syscalls.  It  wasn't properly advancing
through the list when p_iter was invalid.

Addresses issue #117 

Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>