### PR TITLE
db: Return -EDOM on endian mismatch during arch add

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1089,7 +1089,7 @@ int db_col_merge(struct db_filter_col *col_dst, struct db_filter_col *col_src)
 
 	/* verify that the endianess is a match */
 	if (col_dst->endian != col_src->endian)
-		return -EEXIST;
+		return -EDOM;
 
 	/* make sure we don't have any arch/filter collisions */
 	for (iter_a = 0; iter_a < col_dst->filter_cnt; iter_a++) {
@@ -1286,7 +1286,7 @@ int db_col_db_add(struct db_filter_col *col, struct db_filter *db)
 	struct db_filter **dbs;
 
 	if (col->endian != 0 && col->endian != db->arch->endian)
-		return -EEXIST;
+		return -EDOM;
 
 	if (db_col_arch_exist(col, db->arch->token))
 		return -EEXIST;


### PR DESCRIPTION
This commit clarifies the error code when seccomp_arch_add() or
seccomp_merge() fails due to an endian mismatch.  Previously,
libseccomp would return -EEXIST if the new architecture's
endianness did not match.

This addresses GitHub Issue #86 - BUG: seccomp_arch_add() returns
-EEXISTS on endian mismatch

Reported-by: Michael Vogt <michael.vogt@gmail.com>
Suggested-by: Paul Moore <paul@paul-moore.com>
Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>