### PR TITLE
BUG: define the Cython "language_level"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -109,8 +109,8 @@ AC_ARG_ENABLE([python],
 	[build the python bindings, requires cython])])
 AS_IF([test "$enable_python" = yes], [
 	# cython version check
-	AS_IF([test "$CYTHON_VER_MAJ" -eq 0 -a "$CYTHON_VER_MIN" -lt 16], [
-		AC_MSG_ERROR([python bindings require cython 0.16 or higher])
+	AS_IF([test "$CYTHON_VER_MAJ" -eq 0 -a "$CYTHON_VER_MIN" -lt 29], [
+		AC_MSG_ERROR([python bindings require cython 0.29 or higher])
 	])
 	AM_PATH_PYTHON
 ])

--- a/src/python/seccomp.pyx
+++ b/src/python/seccomp.pyx
@@ -19,6 +19,8 @@
 # along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
+# cython: language_level = 3str
+
 """ Python bindings for the libseccomp library
 
 The libseccomp library provides and easy to use, platform independent,


### PR DESCRIPTION
Set the Cython language level to "3str" which is described in the
Cython 0.29 changelog:

 "A new language level name 3str was added that mostly corresponds to
  language level 3, but keeps unprefixed string literals as type ‘str’
  in both Py2 and Py3, and the builtin ‘str’ type unchanged. This will
  become the default in the next Cython release and is meant to help
  user code a) transition more easily to this new default and
  b) migrate to Python 3 source code semantics without making support
  for Python 2.x difficult."

Signed-off-by: Paul Moore <paul@paul-moore.com>