### PR TITLE
BUG: install the python extension to the root package dir

### DIFF
--- a/src/python/Makefile.am
+++ b/src/python/Makefile.am
@@ -40,12 +40,12 @@ build: ../libseccomp.la libseccomp.pxd seccomp.pyx setup.py
 	${PY_BUILD} && touch build
 
 install-exec-local: build
-	${PY_INSTALL} --install-lib=${DESTDIR}/${pkgpythondir} \
-		--record=${DESTDIR}/${pkgpythondir}/install_files.txt
+	${PY_INSTALL} --install-lib=${DESTDIR}/${pyexecdir} \
+		--record=${DESTDIR}/${pyexecdir}/install_files.txt
 
 uninstall-local:
-	cat ${DESTDIR}/${pkgpythondir}/install_files.txt | xargs ${RM} -f
-	${RM} -f ${DESTDIR}/${pkgpythondir}/install_files.txt
+	cat ${DESTDIR}/${pyexecdir}/install_files.txt | xargs ${RM} -f
+	${RM} -f ${DESTDIR}/${pyexecdir}/install_files.txt
 
 clean-local:
 	[ ${srcdir} == ${builddir} ] || ${RM} -f ${builddir}/seccomp.pyx


### PR DESCRIPTION
Commit 8ad3638ea9023c3948976dfadebd1554380a31c9 effectively added libseccomp/
to the install path of the python extension.
This changed the import module name from "seccomp" to "libseccomp.seccomp",
breaking existing users.

Revert the install path like it was before 2.4.0