### PR TITLE
BUG: ship seccomp-syscalls.h

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -16,4 +16,4 @@
 # along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
-include_HEADERS = seccomp.h
+include_HEADERS = seccomp.h seccomp-syscalls.h


### PR DESCRIPTION
Without this, anything which includes "seccomp.h" will fail when using a build version of libseccomp.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>