### PR TITLE
BUG: api: define __SNR_ppoll again

### DIFF
--- a/include/seccomp-syscalls.h
+++ b/include/seccomp-syscalls.h
@@ -272,6 +272,7 @@
 #define __PNR_timerfd_gettime64			-10238
 #define __PNR_timerfd_settime64			-10239
 #define __PNR_utimensat_time64			-10240
+#define __PNR_ppoll				-10241
 
 /*
  * libseccomp syscall definitions
@@ -1357,6 +1358,12 @@
 #define __SNR_poll			__NR_poll
 #else
 #define __SNR_poll			__PNR_poll
+#endif
+
+#ifdef __NR_ppoll
+#define __SNR_ppoll			__NR_ppoll
+#else
+#define __SNR_ppoll			__PNR_ppoll
 #endif
 
 #ifdef __NR_ppoll_time64


### PR DESCRIPTION
It seems commit bf747eb21e428c2b3ead6ebcca27951b681963a0 accidentally removed the
__SNR_ppoll definition, which breaks building of applications using SCMP_SYS(ppoll). The patch just adds the definition back.