### PR TITLE
BUG: use openat instead of open in test 15

### DIFF
--- a/tests/15-basic-resolver.c
+++ b/tests/15-basic-resolver.c
@@ -55,7 +55,7 @@ int main(int argc, char *argv[])
 	unsigned int arch;
 	char *name = NULL;
 
-	if (seccomp_syscall_resolve_name("open") != __NR_open)
+	if (seccomp_syscall_resolve_name("openat") != __NR_openat)
 		goto fail;
 	if (seccomp_syscall_resolve_name("read") != __NR_read)
 		goto fail;


### PR DESCRIPTION
On arm64, __NR_open is not defined, openat is always used. Let's use openat
instead, which is defined for architectures currently.