### PR TITLE
BUG: use python 3.8 to prevent cython install failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ compiler:
 
 language: python
 python:
-  - "nightly"
+  - "3.8"
 
 addons:
   coverity_scan:


### PR DESCRIPTION
I was able to make the existing tests work by just switching back to the latest stable release of Python. I don't pretend to understand the problems that you were trying to debug @drakenclimber, but perhaps this will work reliably? I had a successful build on it [here](https://travis-ci.com/whereswaldon/libseccomp/builds/143730511).

Signed-off-by: Chris Waldon <chris.waldon@ibm.com>