### PR TITLE
BUG: avoid running live python tests in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ script:
   - ./configure --enable-python
   - make check-build
   - LIBSECCOMP_TSTCFG_STRESSCNT=5 make check
-  - LIBSECCOMP_TSTCFG_TYPE=live make -C tests check
+  - LIBSECCOMP_TSTCFG_TYPE=live LIBSECCOMP_TSTCFG_MODE_LIST=c make -C tests check
   # ubuntu 14.04 (trusty) clang has problems with the cython generated code
   - make clean && ./configure && scan-build --status-bugs make
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ compiler:
   - gcc
 
 language: python
-python:
-  - "nightly"
 
 addons:
   coverity_scan:

--- a/tests/regression
+++ b/tests/regression
@@ -94,6 +94,7 @@ libseccomp regression test automation script
 optional arguments:
   -h             show this help message and exit
   -m MODE        specified the test mode [c (default), python]
+                  can also be set via LIBSECCOMP_TSTCFG_MODE_LIST env variable
   -a             specifies all tests are to be run
   -b BATCH_NAME  specifies batch of tests to be run
   -l [LOG]       specifies log file to write test results to
@@ -1024,6 +1025,9 @@ while getopts "ab:gl:m:s:t:T:vh" opt; do
 		;;
 	esac
 done
+
+# use mode list from environment if provided
+[[ -z $mode_list && -n $LIBSECCOMP_TSTCFG_MODE_LIST ]] && mode_list=$LIBSECCOMP_TSTCFG_MODE_LIST
 
 # determine the mode test automatically
 if [[ -z $mode_list ]]; then


### PR DESCRIPTION
Not sure if this is *how* this should be achieved, but it was the most straightforward way that I could see to change the mode of the `./tests/regression` script from a `make` invocation. There didn't seem to be a way to supply flags directly, so I introduced this new environment variable. Feedback welcome!

`Signed-off-by: Chris Waldon <chris.waldon@ibm.com>`