### PR TITLE
Backports for v2.4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 # Travis CI configuration for libseccomp
 
-# https://docs.travis-ci.com/user/trusty-ci-environment
+# https://docs.travis-ci.com/user/reference/bionic
 # https://wiki.ubuntu.com/Releases
 
-dist: xenial
+dist: bionic
 sudo: false
 
 notifications:

--- a/include/seccomp-syscalls.h
+++ b/include/seccomp-syscalls.h
@@ -272,6 +272,7 @@
 #define __PNR_timerfd_gettime64			-10238
 #define __PNR_timerfd_settime64			-10239
 #define __PNR_utimensat_time64			-10240
+#define __PNR_ppoll				-10241
 
 /*
  * libseccomp syscall definitions
@@ -1357,6 +1358,12 @@
 #define __SNR_poll			__NR_poll
 #else
 #define __SNR_poll			__PNR_poll
+#endif
+
+#ifdef __NR_ppoll
+#define __SNR_ppoll			__NR_ppoll
+#else
+#define __SNR_ppoll			__PNR_ppoll
 #endif
 
 #ifdef __NR_ppoll_time64

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -56,3 +56,4 @@ util.pyc
 48-sim-32b_args
 49-sim-64b_comparisons
 50-sim-hash_collision
+52-basic-load

--- a/tests/15-basic-resolver.c
+++ b/tests/15-basic-resolver.c
@@ -55,15 +55,15 @@ int main(int argc, char *argv[])
 	unsigned int arch;
 	char *name = NULL;
 
-	if (seccomp_syscall_resolve_name("open") != __NR_open)
+	if (seccomp_syscall_resolve_name("open") != __SNR_open)
 		goto fail;
-	if (seccomp_syscall_resolve_name("read") != __NR_read)
+	if (seccomp_syscall_resolve_name("read") != __SNR_read)
 		goto fail;
 	if (seccomp_syscall_resolve_name("INVALID") != __NR_SCMP_ERROR)
 		goto fail;
 
 	rc = seccomp_syscall_resolve_name_rewrite(SCMP_ARCH_NATIVE, "openat");
-	if (rc != __NR_openat)
+	if (rc != __SNR_openat)
 		goto fail;
 
 	while ((arch = arch_list[iter++]) != -1) {

--- a/tests/52-basic-load.c
+++ b/tests/52-basic-load.c
@@ -1,0 +1,48 @@
+/**
+ * Seccomp Library test program
+ *
+ * Copyright (c) 2019 Cisco Systems, Inc. <pmoore2@cisco.com>
+ * Author: Paul Moore <paul@paul-moore.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include <errno.h>
+#include <unistd.h>
+
+#include <seccomp.h>
+
+#include "util.h"
+
+int main(int argc, char *argv[])
+{
+	int rc;
+	struct util_options opts;
+	scmp_filter_ctx ctx = NULL;
+
+	rc = util_getopt(argc, argv, &opts);
+	if (rc < 0)
+		goto out;
+
+	ctx = seccomp_init(SCMP_ACT_ALLOW);
+	if (ctx == NULL)
+		return ENOMEM;
+
+	rc = seccomp_load(ctx);
+
+out:
+	seccomp_release(ctx);
+	return (rc < 0 ? -rc : rc);
+}

--- a/tests/52-basic-load.py
+++ b/tests/52-basic-load.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+#
+# Seccomp Library test program
+#
+# Copyright (c) 2019 Cisco Systems, Inc. <pmoore2@cisco.com>
+# Author: Paul Moore <paul@paul-moore.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+import argparse
+import sys
+
+import util
+
+from seccomp import *
+
+def test():
+    f = SyscallFilter(ALLOW)
+    f.load()
+
+test()
+
+# kate: syntax python;
+# kate: indent-mode python; space-indent on; indent-width 4; mixedindent off;

--- a/tests/52-basic-load.tests
+++ b/tests/52-basic-load.tests
@@ -1,0 +1,11 @@
+#
+# libseccomp regression test automation data
+#
+# Copyright (c) 2013 Red Hat <pmoore@redhat.com>
+# Author: Paul Moore <paul@paul-moore.com>
+#
+
+test type: basic
+
+# Test command
+52-basic-load

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -89,7 +89,8 @@ check_PROGRAMS = \
 	47-live-kill_process \
 	48-sim-32b_args \
 	49-sim-64b_comparisons \
-	50-sim-hash_collision
+	50-sim-hash_collision \
+	52-basic-load
 
 EXTRA_DIST_TESTPYTHON = \
 	util.py \
@@ -141,7 +142,8 @@ EXTRA_DIST_TESTPYTHON = \
 	47-live-kill_process.py \
 	48-sim-32b_args.py \
 	49-sim-64b_comparisons.py \
-	50-sim-hash_collision.py
+	50-sim-hash_collision.py \
+	52-basic-load.py
 
 EXTRA_DIST_TESTCFGS = \
 	01-sim-allow.tests \
@@ -193,7 +195,8 @@ EXTRA_DIST_TESTCFGS = \
 	47-live-kill_process.tests \
 	48-sim-32b_args.tests \
 	49-sim-64b_comparisons.tests \
-	50-sim-hash_collision.tests
+	50-sim-hash_collision.tests \
+	52-basic-load.tests
 
 EXTRA_DIST_TESTSCRIPTS = \
 	38-basic-pfc_coverage.sh 38-basic-pfc_coverage.pfc

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -35,10 +35,7 @@ scmp_bpf_sim_SOURCES = scmp_bpf_sim.c bpf.h util.h
 scmp_api_level_SOURCES = scmp_api_level.c
 
 scmp_sys_resolver_LDADD = ../src/libseccomp.la
-scmp_sys_resolver_LDFLAGS = -static
 scmp_arch_detect_LDADD = ../src/libseccomp.la
-scmp_arch_detect_LDFLAGS = -static
 scmp_bpf_disasm_LDADD = util.la
 scmp_bpf_sim_LDADD = util.la
 scmp_api_level_LDADD = ../src/libseccomp.la
-scmp_api_level_LDFLAGS = -static

--- a/tools/scmp_bpf_sim.c
+++ b/tools/scmp_bpf_sim.c
@@ -289,6 +289,8 @@ int main(int argc, char *argv[])
 				exit_fault(EINVAL);
 			break;
 		case 'f':
+			if (opt_file)
+				exit_fault(EINVAL);
 			opt_file = strdup(optarg);
 			if (opt_file == NULL)
 				exit_fault(ENOMEM);


### PR DESCRIPTION
I looked through the commit log in master since v2.4.2 was released, and these commits were a good fit for the v2.4.3 release.

A few comments:
* I had a small collision backporting https://github.com/seccomp/libseccomp/commit/f1513f7eb2e9879007c23fbc6f0f71049bda7b07 because Test #51 (live user notifications) didn't exist in v2.4.  To keep things consistent between master and v2.4, I didn't renumber the basic load test, so there's no test #51 in the v2.4 branch
* I still need to work on the s390 problems outlined in Issue #193, but that will be a separate review
* Commit b233c4048bf85e5055e6becf2dd23efbf5436a99 didn't apply to the v2.4 branch because we haven't backported the SCMP_FLTATR_CTL_SSB and SCMP_ACT_NOTIFY features