### PR TITLE
BUG: fix building outside source directory

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,7 +66,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 dnl ####
 dnl build flags
 dnl ####
-AM_CPPFLAGS="-I\${top_srcdir}/include"
+AM_CPPFLAGS="-I\${top_srcdir}/include -I\${top_builddir}/include"
 AM_CFLAGS="-Wall"
 AM_LDFLAGS="-Wl,-z -Wl,relro"
 AC_SUBST([AM_CPPFLAGS])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -61,8 +61,7 @@ arch_syscall_check_CFLAGS = ${CODE_COVERAGE_CFLAGS}
 arch_syscall_check_LDFLAGS = ${CODE_COVERAGE_LDFLAGS}
 
 libseccomp_la_SOURCES = ${SOURCES_ALL}
-libseccomp_la_CPPFLAGS = ${AM_CPPFLAGS} ${CODE_COVERAGE_CPPFLAGS} \
-	-I${top_builddir}/include
+libseccomp_la_CPPFLAGS = ${AM_CPPFLAGS} ${CODE_COVERAGE_CPPFLAGS}
 libseccomp_la_CFLAGS = ${AM_CFLAGS} ${CODE_COVERAGE_CFLAGS} ${CFLAGS} \
 	-fPIC -DPIC -fvisibility=hidden
 libseccomp_la_LDFLAGS = ${AM_LDFLAGS} ${CODE_COVERAGE_LDFLAGS} ${LDFLAGS} \


### PR DESCRIPTION
Move -I${top_builddir}/include to toplevel so that it is available in all
subdirs.  This is needed to find <seccomp.h> in the build directory, since
it is now a generated file.

Signed-off-by: Andreas Schwab <schwab@suse.de>