### PR TITLE
RFE: Add RISCV64 support to scripts

### DIFF
--- a/src/arch-syscall-dump.c
+++ b/src/arch-syscall-dump.c
@@ -41,6 +41,7 @@
 #include "arch-parisc.h"
 #include "arch-ppc.h"
 #include "arch-ppc64.h"
+#include "arch-riscv64.h"
 #include "arch-s390.h"
 #include "arch-s390x.h"
 
@@ -126,6 +127,9 @@ int main(int argc, char *argv[])
 		case SCMP_ARCH_PPC64:
 		case SCMP_ARCH_PPC64LE:
 			sys = ppc64_syscall_iterate(iter);
+			break;
+		case SCMP_ARCH_RISCV64:
+			sys = riscv64_syscall_iterate(iter);
 			break;
 		case SCMP_ARCH_S390:
 			sys = s390_syscall_iterate(iter);

--- a/src/arch-syscall-validate
+++ b/src/arch-syscall-validate
@@ -393,6 +393,45 @@ function dump_lib_ppc64() {
 }
 
 #
+# Dump the riscv64 system syscall table
+#
+# Arguments:
+#     1    path to the kernel source
+#
+#  Dump the architecture's syscall table to stdout.
+#
+function dump_sys_riscv64() {
+	gcc -E -dM -I$1/include/uapi \
+		-D__BITS_PER_LONG=64 -D__ARCH_WANT_NEW_STAT \
+		$1/include/uapi/asm-generic/unistd.h | \
+		grep "^#define __NR_" | \
+		sed -e '/__NR_syscalls/d' | \
+		sed -e '/__NR_arch_specific_syscall/d' | \
+		sed -e 's/#define[ \t]\+__NR_\([^ \t]\+\)[ \t]\+\(.*\)/\1\t\2/' | \
+		sed -e 's/__NR3264_fadvise64/223/' | \
+		sed -e 's/__NR3264_fcntl/25/' | \
+		sed -e 's/__NR3264_fstatat/79/' | \
+		sed -e 's/__NR3264_fstatfs/44/' | \
+		sed -e 's/__NR3264_ftruncate/46/' | \
+		sed -e 's/__NR3264_lseek/62/' | \
+		sed -e 's/__NR3264_mmap/222/' | \
+		sed -e 's/__NR3264_sendfile/71/' | \
+		sed -e 's/__NR3264_statfs/43/' | \
+		sed -e 's/__NR3264_truncate/45/' | \
+		sed -e 's/__NR3264_fstat/80/' | \
+		sort
+}
+
+#
+# Dump the riscv64 library syscall table
+#
+#  Dump the library's syscall table to stdout.
+#
+function dump_lib_riscv64() {
+	dump_lib_arch riscv64
+}
+
+#
 # Dump the s390 system syscall table
 #
 # Arguments:
@@ -487,6 +526,9 @@ function dump_sys() {
 	ppc64)
 		dump_sys_ppc64 "$2"
 		;;
+	riscv64)
+		dump_sys_riscv64 "$2"
+		;;
 	s390)
 		dump_sys_s390 "$2"
 		;;
@@ -541,6 +583,9 @@ function dump_lib() {
 		;;
 	ppc64)
 		dump_lib_ppc64 "$2"
+		;;
+	riscv64)
+		dump_lib_riscv64 "$2"
 		;;
 	s390)
 		dump_lib_s390 "$2"


### PR DESCRIPTION
This patchset adds riscv64 support to arch-syscall-dump and arch-syscall-validate.

When working on other libseccomp issues, I noticed both of these scripts were missing riscv64 support.  It's possible there are other scripts that need to be updated as well.