### PR TITLE
RFE: enable aarch64 tests in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,13 @@ notifications:
     on_success: always
     on_failure: always
 
+arch:
+  - amd64
+  - arm64
+
+os:
+  - linux
+
 language: c
 compiler:
   - gcc
@@ -58,12 +65,15 @@ script:
   - make check-build
   - LIBSECCOMP_TSTCFG_STRESSCNT=5 make check
   - LIBSECCOMP_TSTCFG_TYPE=live LIBSECCOMP_TSTCFG_MODE_LIST=c make -C tests check
-  # ubuntu 14.04 (trusty) clang has problems with the cython generated code
-  - make clean && ./configure && scan-build --status-bugs make
+  - |
+    if [ $TRAVIS_CPU_ARCH == "x86_64" -o -x scan-build ]; then
+      make clean && ./configure && scan-build --status-bugs make
+    fi
 
 after_success:
   # limit the code coverage tests to the 'test-code-coverage' target
-  - make clean && ./configure --enable-code-coverage && make test-code-coverage
   # https://github.com/eddyxu/cpp-coveralls/blob/master/README.md
-  - coveralls --gcov-options '\-lp'
-    --exclude tests --exclude tools --exclude src/arch-syscall-check.c
+  - |
+    if [ $TRAVIS_CPU_ARCH == "x86_64" ]; then
+      make clean && ./configure --enable-code-coverage && make test-code-coverage && coveralls --gcov-options '\-lp' --exclude tests --exclude tools --exclude src/arch-syscall-check.c
+    fi

--- a/tests/regression
+++ b/tests/regression
@@ -272,7 +272,8 @@ function generate_random_data() {
 	else
 		rcount=$[ ($RANDOM % 8) + 1 ]
 	fi
-	rdata=$(echo $(</dev/urandom tr -dc A-Za-z0-9 | head -c"$rcount"))
+	rdata=$(dd if=/dev/urandom bs=64 count=1 status=none | \
+		md5sum | awk '{ print $1 }' | head -c"$rcount")
 	echo "$rdata"
 }
 


### PR DESCRIPTION
We need to test on as many platforms as we have available to us.  I'm also going to submit PRs for ppc64le and s390x, but sadly those have test failures that we will need to track down before merging.