### PR TITLE
RFE: enable s390x and ppc64le in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ notifications:
 arch:
   - amd64
   - arm64
+  - s390x
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ arch:
   - amd64
   - arm64
   - s390x
+  - ppc64le
 
 os:
   - linux


### PR DESCRIPTION
Add the s390x and ppc64le architectures in the Travis CI builds.  Hold this PR until the test errors have been resolved in Travis.