### PR TITLE
RFE: include a Python package MANIFEST

### DIFF
--- a/src/python/MANIFEST.in
+++ b/src/python/MANIFEST.in
@@ -1,0 +1,4 @@
+include MANIFEST.in
+include *.pyx
+include *.py
+include *.pxd


### PR DESCRIPTION
MANIFEST.in is the list of files that should be included when creating a source
package or binary package installable via pip.

This is a step towards fixing #61.