### PR TITLE
RFE: dynamically link the Python bindings against the main libseccomp library

### DIFF
--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -40,8 +40,8 @@ setup(
 	cmdclass = {'build_ext': build_ext},
 	ext_modules = [
 		Extension("seccomp", ["seccomp.pyx"],
-			# unable to handle libtool libraries directly
-			extra_objects=["../.libs/libseccomp.a"],
+			# Dynamically link against libseccomp.so.
+			libraires=['seccomp'],
 			# fix build warnings, see PEP 3123
 			extra_compile_args=["-fno-strict-aliasing"])
 	]


### PR DESCRIPTION
This allows the Python package to dynamically link against libseccomp installed
on the host when installed so it can be shared via PyPI easily.

This is a draft because I still need to update makefile to point to right library to link against when developing instead of installing. Builds are probably gonna fail right now, but I am working on it.

For reference: https://cython.readthedocs.io/en/latest/src/tutorial/clibraries.html#dynamic-linking

Fix #61 