### PR TITLE
BUG: update the s390 and s390x munge functions

### DIFF
--- a/src/arch-s390.c
+++ b/src/arch-s390.c
@@ -44,12 +44,26 @@ int s390_syscall_resolve_name_munge(const char *name)
 		return __PNR_getsockopt;
 	else if (strcmp(name, "listen") == 0)
 		return __PNR_listen;
+	else if (strcmp(name, "msgctl") == 0)
+		return __PNR_msgctl;
+	else if (strcmp(name, "msgget") == 0)
+		return __PNR_msgget;
+	else if (strcmp(name, "msgrcv") == 0)
+		return __PNR_msgrcv;
+	else if (strcmp(name, "msgsnd") == 0)
+		return __PNR_msgsnd;
 	else if (strcmp(name, "recv") == 0)
 		return __PNR_recv;
 	else if (strcmp(name, "recvfrom") == 0)
 		return __PNR_recvfrom;
 	else if (strcmp(name, "recvmsg") == 0)
 		return __PNR_recvmsg;
+	else if (strcmp(name, "semctl") == 0)
+		return __PNR_semctl;
+	else if (strcmp(name, "semget") == 0)
+		return __PNR_semget;
+	else if (strcmp(name, "semtimedop") == 0)
+		return __PNR_semtimedop;
 	else if (strcmp(name, "recvmmsg") == 0)
 		return __PNR_recvmmsg;
 	else if (strcmp(name, "send") == 0)
@@ -107,6 +121,14 @@ const char *s390_syscall_resolve_num_munge(int num)
 		return "getsockopt";
 	else if (num == __PNR_listen)
 		return "listen";
+	else if (num == __PNR_msgctl)
+		return "msgctl";
+	else if (num == __PNR_msgget)
+		return "msgget";
+	else if (num == __PNR_msgrcv)
+		return "msgrcv";
+	else if (num == __PNR_msgsnd)
+		return "msgsnd";
 	else if (num == __PNR_recv)
 		return "recv";
 	else if (num == __PNR_recvfrom)
@@ -115,6 +137,12 @@ const char *s390_syscall_resolve_num_munge(int num)
 		return "recvmsg";
 	else if (num == __PNR_recvmmsg)
 		return "recvmmsg";
+	else if (num == __PNR_semctl)
+		return "semctl";
+	else if (num == __PNR_semget)
+		return "semget";
+	else if (num == __PNR_semtimedop)
+		return "semtimedop";
 	else if (num == __PNR_send)
 		return "send";
 	else if (num == __PNR_sendmsg)

--- a/src/arch-s390.c
+++ b/src/arch-s390.c
@@ -252,8 +252,8 @@ static int _s390_syscall_demux(int syscall)
 		/* semctl */
 		return 394;
 	case -204:
-		/* semtimedop - not defined */
-		return __NR_SCMP_UNDEF;
+		/* semtimedop */
+		return 392;
 	case -211:
 		/* msgsnd */
 		return 400;
@@ -376,6 +376,9 @@ static int _s390_syscall_mux(int syscall)
 	case 396:
 		/* shmctl */
 		return -224;
+	case 392:
+		/* semtimedop */
+		return -204;
 	}
 
 	return __NR_SCMP_ERROR;

--- a/src/arch-s390x.c
+++ b/src/arch-s390x.c
@@ -44,6 +44,14 @@ int s390x_syscall_resolve_name_munge(const char *name)
 		return __PNR_getsockopt;
 	else if (strcmp(name, "listen") == 0)
 		return __PNR_listen;
+	else if (strcmp(name, "msgctl") == 0)
+		return __PNR_msgctl;
+	else if (strcmp(name, "msgget") == 0)
+		return __PNR_msgget;
+	else if (strcmp(name, "msgrcv") == 0)
+		return __PNR_msgrcv;
+	else if (strcmp(name, "msgsnd") == 0)
+		return __PNR_msgsnd;
 	else if (strcmp(name, "recv") == 0)
 		return __PNR_recv;
 	else if (strcmp(name, "recvfrom") == 0)
@@ -52,6 +60,12 @@ int s390x_syscall_resolve_name_munge(const char *name)
 		return __PNR_recvmsg;
 	else if (strcmp(name, "recvmmsg") == 0)
 		return __PNR_recvmmsg;
+	else if (strcmp(name, "semctl") == 0)
+		return __PNR_semctl;
+	else if (strcmp(name, "semget") == 0)
+		return __PNR_semget;
+	else if (strcmp(name, "semtimedop") == 0)
+		return __PNR_semtimedop;
 	else if (strcmp(name, "send") == 0)
 		return __PNR_send;
 	else if (strcmp(name, "sendmsg") == 0)
@@ -107,6 +121,14 @@ const char *s390x_syscall_resolve_num_munge(int num)
 		return "getsockopt";
 	else if (num == __PNR_listen)
 		return "listen";
+	else if (num == __PNR_msgctl)
+		return "msgctl";
+	else if (num == __PNR_msgget)
+		return "msgget";
+	else if (num == __PNR_msgrcv)
+		return "msgrcv";
+	else if (num == __PNR_msgsnd)
+		return "msgsnd";
 	else if (num == __PNR_recv)
 		return "recv";
 	else if (num == __PNR_recvfrom)
@@ -115,6 +137,12 @@ const char *s390x_syscall_resolve_num_munge(int num)
 		return "recvmsg";
 	else if (num == __PNR_recvmmsg)
 		return "recvmmsg";
+	else if (num == __PNR_semctl)
+		return "semctl";
+	else if (num == __PNR_semget)
+		return "semget";
+	else if (num == __PNR_semtimedop)
+		return "semtimedop";
 	else if (num == __PNR_send)
 		return "send";
 	else if (num == __PNR_sendmsg)


### PR DESCRIPTION
The s390 and s390x munge functions were missing a few syscalls and that was causing failures in the s390x TravisCI run.

This is another step to resolving pull request #215 