### PR TITLE
BUG: fix api update to check if SCMP_ACT_NOTIFY is supported

### DIFF
--- a/include/seccomp.h.in
+++ b/include/seccomp.h.in
@@ -413,6 +413,9 @@ const struct scmp_version *seccomp_version(void);
  *      support for the SCMP_ACT_KILL_PROCESS action
  *  4 : support for the SCMP_FLTATR_CTL_SSB filter attrbute
  *  5 : support for the SCMP_ACT_NOTIFY action
+ *      support for using seccomp_notify_receive()
+ *      support for using seccomp_notify_respond()
+ *      support for using seccomp_notify_id_valid()
  *
  */
 unsigned int seccomp_api_get(void);

--- a/src/api.c
+++ b/src/api.c
@@ -115,7 +115,8 @@ static unsigned int _seccomp_api_update(void)
 		level = 4;
 
 	if (level == 4 &&
-	    sys_chk_seccomp_flag(SECCOMP_FILTER_FLAG_NEW_LISTENER) == 1)
+	    sys_chk_seccomp_flag(SECCOMP_FILTER_FLAG_NEW_LISTENER) == 1 &&
+	    sys_chk_seccomp_action(SCMP_ACT_NOTIFY) == 1)
 		level = 5;
 
 	/* update the stored api level and return */


### PR DESCRIPTION
The function of `_seccomp_api_update` needs to check if the action of `SCMP_ACT_NOTIFY` is supported at level 5 like `SCMP_ACT_LOG` at level 3.
Especially, the result of `sys_chk_seccomp_action` will affect `_support_seccomp_user_notif`

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>