### PR TITLE
BUG: fix api update to check if SCMP_ACT_KILL_PROCESS is supported

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -107,7 +107,8 @@ static unsigned int _seccomp_api_update(void)
 	/* level 3 */
 	if (level == 2 &&
 	    sys_chk_seccomp_flag(SECCOMP_FILTER_FLAG_LOG) == 1 &&
-	    sys_chk_seccomp_action(SCMP_ACT_LOG) == 1)
+	    sys_chk_seccomp_action(SCMP_ACT_LOG) == 1 &&
+	    sys_chk_seccomp_action(SCMP_ACT_KILL_PROCESS) == 1)
 		level = 3;
 
 	if (level == 3 &&


### PR DESCRIPTION
We need to update the level3 handling for kill process as @drakenclimber pointed out.
https://github.com/seccomp/libseccomp/pull/232#issuecomment-629254866

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>