### PR TITLE
RFE: cleanup the API return values and document them the in the manpages

### DIFF
--- a/doc/man/man3/seccomp_arch_add.3
+++ b/doc/man/man3/seccomp_arch_add.3
@@ -86,13 +86,28 @@ new architecture will be added to all of the architectures in the filter.
 .SH RETURN VALUE
 .\" //////////////////////////////////////////////////////////////////////////
 The
-.BR seccomp_arch_add ()
+.BR seccomp_arch_add (),
+.BR seccomp_arch_remove (),
 and
-.BR seccomp_arch_remove ()
-functions return zero on success, negative errno values on failure.  The
 .BR seccomp_arch_exist ()
-function returns zero if the architecture exists, \-EEXIST if it does not, and
-other negative errno values on failure.
+functions return zero on success or one of the following error codes on
+failure:
+.TP
+.B -EDOM
+Architecture specific failure.
+.TP
+.B -EEXIST
+In the case of
+.BR seccomp_arch_add ()
+the architecture already exists and in the case of
+.BR seccomp_arch_remove ()
+the architecture does not exist.
+.TP
+.B -EINVAL
+Invalid input, either the context or architecture token is invalid.
+.TP
+.B -ENOMEM
+The library was unable to allocate enough memory.
 .\" //////////////////////////////////////////////////////////////////////////
 .SH EXAMPLES
 .\" //////////////////////////////////////////////////////////////////////////

--- a/doc/man/man3/seccomp_attr_set.3
+++ b/doc/man/man3/seccomp_attr_set.3
@@ -1,4 +1,4 @@
-.TH "seccomp_attr_set" 3 "30 May 2020" "paul@paul-moore.com" "libseccomp Documentation"
+.TH "seccomp_attr_set" 3 "06 June 2020" "paul@paul-moore.com" "libseccomp Documentation"
 .\" //////////////////////////////////////////////////////////////////////////
 .SH NAME
 .\" //////////////////////////////////////////////////////////////////////////
@@ -98,6 +98,12 @@ action. Defaults to off (
 .B SCMP_FLTATR_CTL_SSB
 A flag to disable Speculative Store Bypass mitigations for this filter.
 Defaults to off (
+.I value
+== 0).
+.TP
+.B SCMP_FLTATR_API_SYSRAWRC
+A flag to specify if libseccomp should pass system error codes back to the
+caller instead of the default -ECANCELED.  Defaults to off (
 .I value
 == 0).
 .\" //////////////////////////////////////////////////////////////////////////

--- a/doc/man/man3/seccomp_attr_set.3
+++ b/doc/man/man3/seccomp_attr_set.3
@@ -1,4 +1,4 @@
-.TH "seccomp_attr_set" 3 "21 August 2014" "paul@paul-moore.com" "libseccomp Documentation"
+.TH "seccomp_attr_set" 3 "30 May 2020" "paul@paul-moore.com" "libseccomp Documentation"
 .\" //////////////////////////////////////////////////////////////////////////
 .SH NAME
 .\" //////////////////////////////////////////////////////////////////////////
@@ -103,7 +103,20 @@ Defaults to off (
 .\" //////////////////////////////////////////////////////////////////////////
 .SH RETURN VALUE
 .\" //////////////////////////////////////////////////////////////////////////
-Returns zero on success, negative errno values on failure.
+Returns zero on success or one of the following error codes on
+failure:
+.TP
+.B -EACCES
+Setting the attribute with the given value is not allowed.
+.TP
+.B -EEXIST
+The attribute does not exist.
+.TP
+.B -EINVAL
+Invalid input, either the context or architecture token is invalid.
+.TP
+.B -EOPNOTSUPP
+The library doesn't support the particular operation.
 .\" //////////////////////////////////////////////////////////////////////////
 .SH EXAMPLES
 .\" //////////////////////////////////////////////////////////////////////////

--- a/doc/man/man3/seccomp_export_bpf.3
+++ b/doc/man/man3/seccomp_export_bpf.3
@@ -51,6 +51,9 @@ failure:
 .B -ECANCELED
 There was a kernel failure beyond the control of the library.
 .TP
+.B -EFAULT
+Internal libseccomp failure.
+.TP
 .B -EINVAL
 Invalid input, either the context or architecture token is invalid.
 .TP

--- a/doc/man/man3/seccomp_export_bpf.3
+++ b/doc/man/man3/seccomp_export_bpf.3
@@ -1,4 +1,4 @@
-.TH "seccomp_export_bpf" 3 "25 July 2012" "paul@paul-moore.com" "libseccomp Documentation"
+.TH "seccomp_export_bpf" 3 "30 May 2020" "paul@paul-moore.com" "libseccomp Documentation"
 .\" //////////////////////////////////////////////////////////////////////////
 .SH NAME
 .\" //////////////////////////////////////////////////////////////////////////
@@ -45,7 +45,17 @@ ordering, are not guaranteed to be the same in both the BPF and PFC formats.
 .\" //////////////////////////////////////////////////////////////////////////
 .SH RETURN VALUE
 .\" //////////////////////////////////////////////////////////////////////////
-Returns zero on success, negative errno values on failure.
+Return zero on success or one of the following error codes on
+failure:
+.TP
+.B -ECANCELED
+There was a kernel failure beyond the control of the library.
+.TP
+.B -EINVAL
+Invalid input, either the context or architecture token is invalid.
+.TP
+.B -ENOMEM
+The library was unable to allocate enough memory.
 .\" //////////////////////////////////////////////////////////////////////////
 .SH EXAMPLES
 .\" //////////////////////////////////////////////////////////////////////////

--- a/doc/man/man3/seccomp_export_bpf.3
+++ b/doc/man/man3/seccomp_export_bpf.3
@@ -49,7 +49,7 @@ Return zero on success or one of the following error codes on
 failure:
 .TP
 .B -ECANCELED
-There was a kernel failure beyond the control of the library.
+There was a system failure beyond the control of the library.
 .TP
 .B -EFAULT
 Internal libseccomp failure.
@@ -59,6 +59,11 @@ Invalid input, either the context or architecture token is invalid.
 .TP
 .B -ENOMEM
 The library was unable to allocate enough memory.
+.P
+If the \fISCMP_FLTATR_API_SYSRAWRC\fP filter attribute is non-zero then
+additional error codes may be returned to the caller; these additional error
+codes are the negative \fIerrno\fP values returned by the system.  Unfortunately
+libseccomp can make no guarantees about these return values.
 .\" //////////////////////////////////////////////////////////////////////////
 .SH EXAMPLES
 .\" //////////////////////////////////////////////////////////////////////////

--- a/doc/man/man3/seccomp_init.3
+++ b/doc/man/man3/seccomp_init.3
@@ -1,4 +1,4 @@
-.TH "seccomp_init" 3 "25 July 2012" "paul@paul-moore.com" "libseccomp Documentation"
+.TH "seccomp_init" 3 "30 May 2020" "paul@paul-moore.com" "libseccomp Documentation"
 .\" //////////////////////////////////////////////////////////////////////////
 .SH NAME
 .\" //////////////////////////////////////////////////////////////////////////
@@ -98,7 +98,14 @@ The
 .BR seccomp_init ()
 function returns a filter context on success, NULL on failure.  The
 .BR seccomp_reset ()
-function returns zero on success, negative errno values on failure.
+function returns zero on success or one of the following error codes on
+failure:
+.TP
+.B -EINVAL
+Invalid input, either the context or action is invalid.
+.TP
+.B -ENOMEM
+The library was unable to allocate enough memory.
 .\" //////////////////////////////////////////////////////////////////////////
 .SH EXAMPLES
 .\" //////////////////////////////////////////////////////////////////////////

--- a/doc/man/man3/seccomp_load.3
+++ b/doc/man/man3/seccomp_load.3
@@ -39,7 +39,7 @@ is "stricter" than
 Returns zero on success or one of the following error codes on failure:
 .TP
 .B -ECANCELED
-There was a kernel failure beyond the control of the library.
+There was a system failure beyond the control of the library.
 .TP
 .B -EFAULT
 Internal libseccomp failure.
@@ -52,6 +52,11 @@ The library was unable to allocate enough memory.
 .TP
 .B -ESRCH
 Unable to load the filter due to thread issues.
+.P
+If the \fISCMP_FLTATR_API_SYSRAWRC\fP filter attribute is non-zero then
+additional error codes may be returned to the caller; these additional error
+codes are the negative \fIerrno\fP values returned by the system.  Unfortunately
+libseccomp can make no guarantees about these return values.
 .\" //////////////////////////////////////////////////////////////////////////
 .SH EXAMPLES
 .\" //////////////////////////////////////////////////////////////////////////

--- a/doc/man/man3/seccomp_load.3
+++ b/doc/man/man3/seccomp_load.3
@@ -41,6 +41,9 @@ Returns zero on success or one of the following error codes on failure:
 .B -ECANCELED
 There was a kernel failure beyond the control of the library.
 .TP
+.B -EFAULT
+Internal libseccomp failure.
+.TP
 .B -EINVAL
 Invalid input, either the context or architecture token is invalid.
 .TP

--- a/doc/man/man3/seccomp_load.3
+++ b/doc/man/man3/seccomp_load.3
@@ -1,4 +1,4 @@
-.TH "seccomp_load" 3 "25 July 2012" "paul@paul-moore.com" "libseccomp Documentation"
+.TH "seccomp_load" 3 "30 May 2020" "paul@paul-moore.com" "libseccomp Documentation"
 .\" //////////////////////////////////////////////////////////////////////////
 .SH NAME
 .\" //////////////////////////////////////////////////////////////////////////
@@ -36,7 +36,19 @@ is "stricter" than
 .\" //////////////////////////////////////////////////////////////////////////
 .SH RETURN VALUE
 .\" //////////////////////////////////////////////////////////////////////////
-Returns zero on success, negative errno values on failure.
+Returns zero on success or one of the following error codes on failure:
+.TP
+.B -ECANCELED
+There was a kernel failure beyond the control of the library.
+.TP
+.B -EINVAL
+Invalid input, either the context or architecture token is invalid.
+.TP
+.B -ENOMEM
+The library was unable to allocate enough memory.
+.TP
+.B -ESRCH
+Unable to load the filter due to thread issues.
 .\" //////////////////////////////////////////////////////////////////////////
 .SH EXAMPLES
 .\" //////////////////////////////////////////////////////////////////////////

--- a/doc/man/man3/seccomp_merge.3
+++ b/doc/man/man3/seccomp_merge.3
@@ -1,4 +1,4 @@
-.TH "seccomp_merge" 3 "28 September 2012" "paul@paul-moore.com" "libseccomp Documentation"
+.TH "seccomp_merge" 3 "30 May 2020" "paul@paul-moore.com" "libseccomp Documentation"
 .\" //////////////////////////////////////////////////////////////////////////
 .SH NAME
 .\" //////////////////////////////////////////////////////////////////////////
@@ -41,7 +41,21 @@ attribute values and no overlapping architectures.
 .\" //////////////////////////////////////////////////////////////////////////
 .SH RETURN VALUE
 .\" //////////////////////////////////////////////////////////////////////////
-Returns zero on success and negative values on failure.
+Returns zero on success or one of the following error codes on
+failure:
+.TP
+.B -EDOM
+Unable to merge the filters due to architecture issues, e.g. byte endian
+mismatches.
+.TP
+.B -EEXIST
+The architecture already exists in the filter.
+.TP
+.B -EINVAL
+One of the filters is invalid.
+.TP
+.B -ENOMEM
+The library was unable to allocate enough memory.
 .\" //////////////////////////////////////////////////////////////////////////
 .SH EXAMPLES
 .\" //////////////////////////////////////////////////////////////////////////

--- a/doc/man/man3/seccomp_notify_alloc.3
+++ b/doc/man/man3/seccomp_notify_alloc.3
@@ -47,7 +47,7 @@ this response corresponds to.
 .P
 The
 .BR seccomp_notify_id_valid ()
-function checks to see if the syscall from a particualr notification request is
+function checks to see if the syscall from a particular notification request is
 still valid, i.e. if the task is still alive. See NOTES below for details on
 race conditions.
 .P
@@ -70,11 +70,12 @@ The
 .BR seccomp_notify_receive (),
 and
 .BR seccomp_notify_respond ()
-functions return zero on success or one of the following error codes on
+functions return zero on success,  or one of the following error codes on
 failure:
 .TP
 .B -ECANCELED
-There was a kernel failure beyond the control of the library.
+There was a system failure beyond the control of the library, check the
+\fIerrno\fP value for more information.
 .TP
 .B -EFAULT
 Internal libseccomp failure.

--- a/doc/man/man3/seccomp_notify_alloc.3
+++ b/doc/man/man3/seccomp_notify_alloc.3
@@ -1,4 +1,4 @@
-.TH "seccomp_notify_alloc" 3 "24 April 2019" "tycho@tycho.ws" "libseccomp Documentation"
+.TH "seccomp_notify_alloc" 3 "30 May 2020" "tycho@tycho.ws" "libseccomp Documentation"
 .\" //////////////////////////////////////////////////////////////////////////
 .SH NAME
 .\" //////////////////////////////////////////////////////////////////////////
@@ -57,21 +57,33 @@ returns the notification fd of a filter after it has been loaded.
 .\" //////////////////////////////////////////////////////////////////////////
 .SH RETURN VALUE
 .\" //////////////////////////////////////////////////////////////////////////
-.P
 The
-.BR seccomp_notify_alloc (),
-.BR seccomp_notify_receive (),
-and
-.BR seccomp_notify_respond ()
-functions all return 0 on success, -1 on failure.
+.BR seccomp_notify_fd ()
+returns the notification fd of the loaded filter.
 .P
 The
 .BR seccomp_notify_id_valid ()
 returns 0 if the id is valid, and -ENOENT if it is not.
 .P
 The
-.BR seccomp_notify_fd ()
-returns the notification fd of the loaded filter.
+.BR seccomp_notify_alloc (),
+.BR seccomp_notify_receive (),
+and
+.BR seccomp_notify_respond ()
+functions return zero on success or one of the following error codes on
+failure:
+.TP
+.B -ECANCELED
+There was a kernel failure beyond the control of the library.
+.TP
+.B -EFAULT
+Internal libseccomp failure.
+.TP
+.B -ENOMEM
+The library was unable to allocate enough memory.
+.TP
+.B -EOPNOTSUPP
+The library doesn't support the particular operation.
 .\" //////////////////////////////////////////////////////////////////////////
 .SH NOTES
 .\" //////////////////////////////////////////////////////////////////////////

--- a/doc/man/man3/seccomp_rule_add.3
+++ b/doc/man/man3/seccomp_rule_add.3
@@ -1,4 +1,4 @@
-.TH "seccomp_rule_add" 3 "17 February 2019" "paul@paul-moore.com" "libseccomp Documentation"
+.TH "seccomp_rule_add" 3 "30 May 2020" "paul@paul-moore.com" "libseccomp Documentation"
 .\" //////////////////////////////////////////////////////////////////////////
 .SH NAME
 .\" //////////////////////////////////////////////////////////////////////////
@@ -279,12 +279,47 @@ SCMP_CMP(
 .SH RETURN VALUE
 .\" //////////////////////////////////////////////////////////////////////////
 The
+.BR SCMP_SYS ()
+macro returns a value suitable for use as the
+.I syscall
+value in the
+.BR seccomp_rule_add* ()
+functions.  In a similar manner, the
+.BR SCMP_CMP ()
+and
+.BR SCMP_A* ()
+macros return values suitable for use as argument comparisons in the
+.BR seccomp_rule_add ()
+and
+.BR seccomp_rule_add_exact ()
+functions.
+.P
+The
 .BR seccomp_rule_add (),
 .BR seccomp_rule_add_array (),
 .BR seccomp_rule_add_exact (),
 and
 .BR seccomp_rule_add_exact_array ()
-functions return zero on success, negative errno values on failure.
+functions return zero on success or one of the following error codes on
+failure:
+.TP
+.B -EDOM
+Architecture specific failure.
+.TP
+.B -EEXIST
+The rule already exists.
+.TP
+.B -EFAULT
+Internal libseccomp failure.
+.TP
+.B -EINVAL
+Invalid input, either the context or architecture token is invalid.
+.TP
+.B -ENOMEM
+The library was unable to allocate enough memory.
+.TP
+.B -EOPNOTSUPP
+The library doesn't support the particular operation.
 .\" //////////////////////////////////////////////////////////////////////////
 .SH EXAMPLES
 .\" //////////////////////////////////////////////////////////////////////////

--- a/doc/man/man3/seccomp_syscall_priority.3
+++ b/doc/man/man3/seccomp_syscall_priority.3
@@ -1,4 +1,4 @@
-.TH "seccomp_syscall_priority" 3 "25 July 2012" "paul@paul-moore.com" "libseccomp Documentation"
+.TH "seccomp_syscall_priority" 3 "30 May 2020" "paul@paul-moore.com" "libseccomp Documentation"
 .\" //////////////////////////////////////////////////////////////////////////
 .SH NAME
 .\" //////////////////////////////////////////////////////////////////////////
@@ -53,13 +53,28 @@ is the value returned by the call to
 .SH RETURN VALUE
 .\" //////////////////////////////////////////////////////////////////////////
 The
-.BR seccomp_syscall_priority ()
-function returns zero on success, negative errno values on failure.  The
 .BR SCMP_SYS ()
 macro returns a value suitable for use as the
 .I syscall
 value in
 .BR seccomp_syscall_priority ().
+.P
+The
+.BR seccomp_syscall_priority ()
+function returns zero on success or one of the following error codes on
+failure:
+.TP
+.B -EDOM
+Architecture specific failure.
+.TP
+.B -EFAULT
+Internal libseccomp failure.
+.TP
+.B -EINVAL
+Invalid input, either the context or architecture token is invalid.
+.TP
+.B -ENOMEM
+The library was unable to allocate enough memory.
 .\" //////////////////////////////////////////////////////////////////////////
 .SH EXAMPLES
 .\" //////////////////////////////////////////////////////////////////////////

--- a/include/seccomp.h.in
+++ b/include/seccomp.h.in
@@ -76,6 +76,7 @@ enum scmp_filter_attr {
 					 * 2 - binary tree sorted by syscall
 					 *     number
 					 */
+	SCMP_FLTATR_API_SYSRAWRC = 9,	/**< return the system return codes */
 	_SCMP_FLTATR_MAX,
 };
 

--- a/include/seccomp.h.in
+++ b/include/seccomp.h.in
@@ -723,7 +723,7 @@ int seccomp_rule_add_exact_array(scmp_filter_ctx ctx,
 				 const struct scmp_arg_cmp *arg_array);
 
 /**
- * Allocate a pair of notification request/response structures.
+ * Allocate a pair of notification request/response structures
  * @param req the request location
  * @param resp the response location
  *
@@ -744,7 +744,7 @@ void seccomp_notify_free(struct seccomp_notif *req,
 			 struct seccomp_notif_resp *resp);
 
 /**
- * Receive a notification from a seccomp notification fd.
+ * Receive a notification from a seccomp notification fd
  * @param fd the notification fd
  * @param req the request buffer to save into
  *
@@ -756,7 +756,7 @@ void seccomp_notify_free(struct seccomp_notif *req,
 int seccomp_notify_receive(int fd, struct seccomp_notif *req);
 
 /**
- * Send a notification response to a seccomp notification fd.
+ * Send a notification response to a seccomp notification fd
  * @param fd the notification fd
  * @param resp the response buffer to use
  *
@@ -768,7 +768,7 @@ int seccomp_notify_receive(int fd, struct seccomp_notif *req);
 int seccomp_notify_respond(int fd, struct seccomp_notif_resp *resp);
 
 /**
- * Check if a notification id is still valid.
+ * Check if a notification id is still valid
  * @param fd the notification fd
  * @param id the id to test
  *
@@ -779,7 +779,7 @@ int seccomp_notify_respond(int fd, struct seccomp_notif_resp *resp);
 int seccomp_notify_id_valid(int fd, uint64_t id);
 
 /**
- * Return the notification fd from a filter that has already been loaded.
+ * Return the notification fd from a filter that has already been loaded
  * @param ctx the filter context
  *
  * This returns the listener fd that was generated when the seccomp policy was

--- a/src/api.c
+++ b/src/api.c
@@ -610,7 +610,7 @@ API int seccomp_export_bpf(const scmp_filter_ctx ctx, int fd)
 	rc = write(fd, program->blks, BPF_PGM_SIZE(program));
 	gen_bpf_release(program);
 	if (rc < 0)
-		return -errno;
+		return -ECANCELED;
 
 	return 0;
 }

--- a/src/api.c
+++ b/src/api.c
@@ -449,7 +449,7 @@ API int seccomp_rule_add_array(scmp_filter_ctx ctx,
 	if (rc < 0)
 		return rc;
 	if (action == col->attr.act_default)
-		return -EPERM;
+		return -EACCES;
 
 	return db_col_rule_add(col, 0, action, syscall, arg_cnt, arg_array);
 }
@@ -498,7 +498,7 @@ API int seccomp_rule_add_exact_array(scmp_filter_ctx ctx,
 	if (rc < 0)
 		return rc;
 	if (action == col->attr.act_default)
-		return -EPERM;
+		return -EACCES;
 
 	if (col->filter_cnt > 1)
 		return -EOPNOTSUPP;

--- a/src/api.c
+++ b/src/api.c
@@ -653,9 +653,9 @@ API int seccomp_export_bpf(const scmp_filter_ctx ctx, int fd)
 	if (_ctx_valid(ctx))
 		return _rc_filter(-EINVAL);
 
-	program = gen_bpf_generate((struct db_filter_col *)ctx);
-	if (program == NULL)
-		return _rc_filter(-ENOMEM);
+	rc = gen_bpf_generate((struct db_filter_col *)ctx, &program);
+	if (rc < 0)
+		return _rc_filter(rc);
 	rc = write(fd, program->blks, BPF_PGM_SIZE(program));
 	gen_bpf_release(program);
 	if (rc < 0)

--- a/src/db.c
+++ b/src/db.c
@@ -1071,6 +1071,7 @@ int db_col_reset(struct db_filter_col *col, uint32_t def_action)
 	col->attr.log_enable = 0;
 	col->attr.spec_allow = 0;
 	col->attr.optimize = 1;
+	col->attr.api_sysrawrc = 0;
 
 	/* set the state */
 	col->state = _DB_STA_VALID;
@@ -1316,12 +1317,34 @@ int db_col_attr_get(const struct db_filter_col *col,
 	case SCMP_FLTATR_CTL_OPTIMIZE:
 		*value = col->attr.optimize;
 		break;
+	case SCMP_FLTATR_API_SYSRAWRC:
+		*value = col->attr.api_sysrawrc;
+		break;
 	default:
 		rc = -EINVAL;
 		break;
 	}
 
 	return rc;
+}
+
+/**
+ * Get a filter attribute
+ * @param col the seccomp filter collection
+ * @param attr the filter attribute
+ *
+ * Returns the requested filter attribute value with zero on any error.
+ * Special care must be given with this function as error conditions can be
+ * hidden from the caller.
+ *
+ */
+uint32_t db_col_attr_read(const struct db_filter_col *col,
+			  enum scmp_filter_attr attr)
+{
+	uint32_t value = 0;
+
+	db_col_attr_get(col, attr, &value);
+	return value;
 }
 
 /**
@@ -1401,6 +1424,9 @@ int db_col_attr_set(struct db_filter_col *col,
 			rc = -EOPNOTSUPP;
 			break;
 		}
+		break;
+	case SCMP_FLTATR_API_SYSRAWRC:
+		col->attr.api_sysrawrc = (value ? 1 : 0);
 		break;
 	default:
 		rc = -EINVAL;

--- a/src/db.c
+++ b/src/db.c
@@ -1317,7 +1317,7 @@ int db_col_attr_get(const struct db_filter_col *col,
 		*value = col->attr.optimize;
 		break;
 	default:
-		rc = -EEXIST;
+		rc = -EINVAL;
 		break;
 	}
 
@@ -1403,7 +1403,7 @@ int db_col_attr_set(struct db_filter_col *col,
 		}
 		break;
 	default:
-		rc = -EEXIST;
+		rc = -EINVAL;
 		break;
 	}
 

--- a/src/db.h
+++ b/src/db.h
@@ -120,6 +120,8 @@ struct db_filter_attr {
 	uint32_t spec_allow;
 	/* SCMP_FLTATR_CTL_OPTIMIZE related attributes */
 	uint32_t optimize;
+	/* return the raw system return codes */
+	uint32_t api_sysrawrc;
 };
 
 struct db_filter {
@@ -191,6 +193,8 @@ int db_col_arch_exist(struct db_filter_col *col, uint32_t arch_token);
 
 int db_col_attr_get(const struct db_filter_col *col,
 		    enum scmp_filter_attr attr, uint32_t *value);
+uint32_t db_col_attr_read(const struct db_filter_col *col,
+			  enum scmp_filter_attr attr);
 int db_col_attr_set(struct db_filter_col *col,
 		    enum scmp_filter_attr attr, uint32_t value);
 

--- a/src/gen_bpf.c
+++ b/src/gen_bpf.c
@@ -1281,7 +1281,7 @@ static int _gen_bpf_insert(struct bpf_state *state, struct bpf_instr *instr,
 
 	*insert = _blk_append(state, existing_blk, instr);
 	if (*insert == NULL)
-		return -EINVAL;
+		return -ENOMEM;
 	(*insert)->next = (*next);
 	if (*next != NULL)
 		(*next)->prev = (*insert);
@@ -1949,9 +1949,6 @@ static int _gen_bpf_build_bpf(struct bpf_state *state,
 	struct db_filter *db_secondary = NULL;
 	struct arch_def pseudo_arch;
 
-	if (col->filter_cnt == 0)
-		return -EINVAL;
-
 	/* create a fake architecture definition for use in the early stages */
 	memset(&pseudo_arch, 0, sizeof(pseudo_arch));
 	pseudo_arch.endian = col->endian;
@@ -2253,6 +2250,9 @@ struct bpf_program *gen_bpf_generate(const struct db_filter_col *col)
 	int rc;
 	struct bpf_state state;
 	struct bpf_program *prgm;
+
+	if (col->filter_cnt == 0)
+		return NULL;
 
 	memset(&state, 0, sizeof(state));
 	state.attr = &col->attr;

--- a/src/gen_bpf.h
+++ b/src/gen_bpf.h
@@ -36,7 +36,8 @@ struct bpf_program {
 #define BPF_PGM_SIZE(x) \
 	((x)->blk_cnt * sizeof(*((x)->blks)))
 
-struct bpf_program *gen_bpf_generate(const struct db_filter_col *col);
+int gen_bpf_generate(const struct db_filter_col *col,
+		     struct bpf_program **prgm_ptr);
 void gen_bpf_release(struct bpf_program *program);
 
 #endif

--- a/src/gen_pfc.c
+++ b/src/gen_pfc.c
@@ -469,18 +469,17 @@ arch_return:
  */
 int gen_pfc_generate(const struct db_filter_col *col, int fd)
 {
-	int rc = 0;
 	int newfd;
 	unsigned int iter;
 	FILE *fds;
 
 	newfd = dup(fd);
 	if (newfd < 0)
-		return errno;
+		return -ECANCELED;
 	fds = fdopen(newfd, "a");
 	if (fds == NULL) {
 		close(newfd);
-		return errno;
+		return -ECANCELED;
 	}
 
 	/* generate the pfc */
@@ -501,5 +500,5 @@ int gen_pfc_generate(const struct db_filter_col *col, int fd)
 	fflush(fds);
 	fclose(fds);
 
-	return rc;
+	return 0;
 }

--- a/src/gen_pfc.c
+++ b/src/gen_pfc.c
@@ -464,7 +464,7 @@ arch_return:
  *
  * This function generates a pseudo filter code representation of the given
  * filter collection and writes it to the given fd.  Returns zero on success,
- * negative values on failure.
+ * negative errno values on failure.
  *
  */
 int gen_pfc_generate(const struct db_filter_col *col, int fd)
@@ -475,11 +475,11 @@ int gen_pfc_generate(const struct db_filter_col *col, int fd)
 
 	newfd = dup(fd);
 	if (newfd < 0)
-		return -ECANCELED;
+		return -errno;
 	fds = fdopen(newfd, "a");
 	if (fds == NULL) {
 		close(newfd);
-		return -ECANCELED;
+		return -errno;
 	}
 
 	/* generate the pfc */

--- a/src/gen_pfc.c
+++ b/src/gen_pfc.c
@@ -289,7 +289,7 @@ static int _get_bintree_syscall_num(const struct pfc_sys_list *cur,
 	}
 
 	if (cur == NULL)
-		return -EINVAL;
+		return -EFAULT;
 
 	*num = cur->sys->num;
 	return 0;

--- a/src/python/libseccomp.pxd
+++ b/src/python/libseccomp.pxd
@@ -62,6 +62,7 @@ cdef extern from "seccomp.h":
         SCMP_FLTATR_CTL_LOG
         SCMP_FLTATR_CTL_SSB
         SCMP_FLTATR_CTL_OPTIMIZE
+        SCMP_FLTATR_API_SYSRAWRC
 
     cdef enum scmp_compare:
         SCMP_CMP_NE

--- a/src/python/seccomp.pyx
+++ b/src/python/seccomp.pyx
@@ -318,6 +318,11 @@ cdef class Attr:
     CTL_TSKIP - allow rules with a -1 syscall number
     CTL_LOG - log not-allowed actions
     CTL_SSB - disable SSB mitigations
+    CTL_OPTIMIZE - the filter's optimization level:
+                   0: currently unused
+                   1: rules weighted by priority and complexity (DEFAULT)
+                   2: binary tree sorted by syscall number
+    API_SYSRAWRC - return the raw syscall codes
     """
     ACT_DEFAULT = libseccomp.SCMP_FLTATR_ACT_DEFAULT
     ACT_BADARCH = libseccomp.SCMP_FLTATR_ACT_BADARCH
@@ -327,6 +332,7 @@ cdef class Attr:
     CTL_LOG = libseccomp.SCMP_FLTATR_CTL_LOG
     CTL_SSB = libseccomp.SCMP_FLTATR_CTL_SSB
     CTL_OPTIMIZE = libseccomp.SCMP_FLTATR_CTL_OPTIMIZE
+    API_SYSRAWRC = libseccomp.SCMP_FLTATR_API_SYSRAWRC
 
 cdef class Arg:
     """ Python object representing a SyscallFilter syscall argument.

--- a/src/system.c
+++ b/src/system.c
@@ -291,6 +291,7 @@ void sys_set_seccomp_flag(int flag, bool enable)
 /**
  * Loads the filter into the kernel
  * @param col the filter collection
+ * @param rawrc pass the raw return code if true
  *
  * This function loads the given seccomp filter context into the kernel.  If
  * the filter was loaded correctly, the kernel will be enforcing the filter
@@ -298,7 +299,7 @@ void sys_set_seccomp_flag(int flag, bool enable)
  * error.
  *
  */
-int sys_filter_load(struct db_filter_col *col)
+int sys_filter_load(struct db_filter_col *col, bool rawrc)
 {
 	int rc;
 	struct bpf_program *prgm = NULL;
@@ -343,7 +344,7 @@ filter_load_out:
 	if (rc == -ESRCH)
 		return -ESRCH;
 	if (rc < 0)
-		return -ECANCELED;
+		return (rawrc ? -errno : -ECANCELED);
 	return rc;
 }
 

--- a/src/system.c
+++ b/src/system.c
@@ -303,9 +303,9 @@ int sys_filter_load(struct db_filter_col *col)
 	int rc;
 	struct bpf_program *prgm = NULL;
 
-	prgm = gen_bpf_generate(col);
-	if (prgm == NULL)
-		return -ENOMEM;
+	rc = gen_bpf_generate(col, &prgm);
+	if (rc < 0)
+		return rc;
 
 	/* attempt to set NO_NEW_PRIVS */
 	if (col->attr.nnp_enable) {

--- a/src/system.c
+++ b/src/system.c
@@ -347,6 +347,16 @@ filter_load_out:
 	return rc;
 }
 
+/**
+ * Allocate a pair of notification request/response structures
+ * @param req the request location
+ * @param resp the response location
+ *
+ * This function allocates a pair of request/response structure by computing
+ * the correct sized based on the currently running kernel. It returns zero on
+ * success, and negative values on failure.
+ *
+ */
 int sys_notify_alloc(struct seccomp_notif **req,
 		     struct seccomp_notif_resp **resp)
 {
@@ -382,6 +392,16 @@ int sys_notify_alloc(struct seccomp_notif **req,
 	return 0;
 }
 
+/**
+ * Receive a notification from a seccomp notification fd
+ * @param fd the notification fd
+ * @param req the request buffer to save into
+ *
+ * Blocks waiting for a notification on this fd. This function is thread safe
+ * (synchronization is performed in the kernel). Returns zero on success,
+ * negative values on error.
+ *
+ */
 int sys_notify_receive(int fd, struct seccomp_notif *req)
 {
 	if (_support_seccomp_user_notif <= 0)
@@ -393,6 +413,16 @@ int sys_notify_receive(int fd, struct seccomp_notif *req)
 	return 0;
 }
 
+/**
+ * Send a notification response to a seccomp notification fd
+ * @param fd the notification fd
+ * @param resp the response buffer to use
+ *
+ * Sends a notification response on this fd. This function is thread safe
+ * (synchronization is performed in the kernel). Returns zero on success,
+ * negative values on error.
+ *
+ */
 int sys_notify_respond(int fd, struct seccomp_notif_resp *resp)
 {
 	if (_support_seccomp_user_notif <= 0)
@@ -403,6 +433,15 @@ int sys_notify_respond(int fd, struct seccomp_notif_resp *resp)
 	return 0;
 }
 
+/**
+ * Check if a notification id is still valid
+ * @param fd the notification fd
+ * @param id the id to test
+ *
+ * Checks to see if a notification id is still valid. Returns 0 on success, and
+ * negative values on failure.
+ *
+ */
 int sys_notify_id_valid(int fd, uint64_t id)
 {
 	if (_support_seccomp_user_notif <= 0)

--- a/src/system.h
+++ b/src/system.h
@@ -188,7 +188,7 @@ void sys_set_seccomp_action(uint32_t action, bool enable);
 int sys_chk_seccomp_flag(int flag);
 void sys_set_seccomp_flag(int flag, bool enable);
 
-int sys_filter_load(struct db_filter_col *col);
+int sys_filter_load(struct db_filter_col *col, bool rawrc);
 
 int sys_notify_alloc(struct seccomp_notif **req,
 		     struct seccomp_notif_resp **resp);

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -62,3 +62,4 @@ util.pyc
 54-live-binary_tree
 55-basic-pfc_binary_tree
 56-basic-iterate_syscalls
+57-basic-rawsysrc

--- a/tests/11-basic-basic_errors.c
+++ b/tests/11-basic-basic_errors.c
@@ -81,7 +81,7 @@ int main(int argc, char *argv[])
 		return -1;
 	else {
 		rc = seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(read), 0);
-		if (rc != -EPERM)
+		if (rc != -EACCES)
 			return -1;
 		rc = seccomp_rule_add(ctx, SCMP_ACT_KILL - 1, SCMP_SYS(read), 0);
 		if (rc != -EINVAL)

--- a/tests/11-basic-basic_errors.c
+++ b/tests/11-basic-basic_errors.c
@@ -178,10 +178,10 @@ int main(int argc, char *argv[])
 	if (ctx == NULL)
 		return -1;
 	rc = seccomp_attr_get(ctx, 1000, &attr);
-	if (rc != -EEXIST)
+	if (rc != -EINVAL)
 		return -1;
 	rc = seccomp_attr_set(ctx, 1000, 1);
-	if (rc != -EEXIST)
+	if (rc != -EINVAL)
 		return -1;
 
 	return 0;

--- a/tests/11-basic-basic_errors.c
+++ b/tests/11-basic-basic_errors.c
@@ -151,7 +151,7 @@ int main(int argc, char *argv[])
 		return -1;
 	else {
 		rc = seccomp_export_pfc(ctx, sysconf(_SC_OPEN_MAX) - 1);
-		if (rc != EBADF)
+		if (rc != -ECANCELED)
 			return -1;
 	}
 	seccomp_release(ctx);
@@ -167,7 +167,7 @@ int main(int argc, char *argv[])
 		return -1;
 	else {
 		rc = seccomp_export_bpf(ctx, sysconf(_SC_OPEN_MAX) - 1);
-		if (rc != -EBADF)
+		if (rc != -ECANCELED)
 			return -1;
 	}
 	seccomp_release(ctx);

--- a/tests/13-basic-attrs.c
+++ b/tests/13-basic-attrs.c
@@ -120,6 +120,28 @@ int main(int argc, char *argv[])
 		goto out;
 	}
 
+	rc = seccomp_attr_set(ctx, SCMP_FLTATR_CTL_OPTIMIZE, 2);
+	if (rc != 0)
+		goto out;
+	rc = seccomp_attr_get(ctx, SCMP_FLTATR_CTL_OPTIMIZE, &val);
+	if (rc != 0)
+		goto out;
+	if (val != 2) {
+		rc = -1;
+		goto out;
+	}
+
+	rc = seccomp_attr_set(ctx, SCMP_FLTATR_API_SYSRAWRC, 1);
+	if (rc != 0)
+		goto out;
+	rc = seccomp_attr_get(ctx, SCMP_FLTATR_API_SYSRAWRC, &val);
+	if (rc != 0)
+		goto out;
+	if (val != 1) {
+		rc = -1;
+		goto out;
+	}
+
 	rc = 0;
 out:
 	seccomp_release(ctx);

--- a/tests/13-basic-attrs.py
+++ b/tests/13-basic-attrs.py
@@ -58,6 +58,9 @@ def test():
     f.set_attr(Attr.CTL_OPTIMIZE, 2)
     if f.get_attr(Attr.CTL_OPTIMIZE) != 2:
         raise RuntimeError("Failed getting Attr.CTL_OPTIMIZE")
+    f.set_attr(Attr.API_SYSRAWRC, 1)
+    if f.get_attr(Attr.API_SYSRAWRC) != 1:
+        raise RuntimeError("Failed getting Attr.API_SYSRAWRC")
 
 test()
 

--- a/tests/57-basic-rawsysrc.c
+++ b/tests/57-basic-rawsysrc.c
@@ -1,0 +1,64 @@
+/**
+ * Seccomp Library test program
+ *
+ * Copyright (c) 2020 Cisco Systems, Inc. <pmoore2@cisco.com>
+ * Author: Paul Moore <paul@paul-moore.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include <seccomp.h>
+
+#include "util.h"
+
+int main(int argc, char *argv[])
+{
+	int rc;
+	int fd;
+	scmp_filter_ctx ctx = NULL;
+
+	rc = seccomp_api_set(3);
+	if (rc != 0)
+		return EOPNOTSUPP;
+
+	ctx = seccomp_init(SCMP_ACT_ALLOW);
+	if (ctx == NULL) {
+		rc = ENOMEM;
+		goto out;
+	}
+
+	rc = seccomp_attr_set(ctx, SCMP_FLTATR_API_SYSRAWRC, 1);
+	if (rc != 0)
+		goto out;
+
+	/* we must use a closed/invalid fd for this to work */
+	fd = dup(2);
+	close(fd);
+	rc = seccomp_export_pfc(ctx, fd);
+	if (rc == -EBADF)
+		rc = 0;
+	else
+		rc = -1;
+
+out:
+	seccomp_release(ctx);
+	return (rc < 0 ? -rc : rc);
+}

--- a/tests/57-basic-rawsysrc.py
+++ b/tests/57-basic-rawsysrc.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+#
+# Seccomp Library test program
+#
+# Copyright (c) 2020 Cisco Systems, Inc. <pmoore2@cisco.com>
+# Author: Paul Moore <paul@paul-moore.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+import argparse
+import sys
+import os
+
+import util
+
+from seccomp import *
+
+def test():
+    # this test really isn't conclusive, but considering how python does error
+    # handling it may be the best we can do
+    f = SyscallFilter(ALLOW)
+    dummy = open("/dev/null", "w")
+    os.close(dummy.fileno())
+    try:
+        f = f.export_pfc(dummy)
+    except RuntimeError:
+        pass
+
+test()
+
+# kate: syntax python;
+# kate: indent-mode python; space-indent on; indent-width 4; mixedindent off;

--- a/tests/57-basic-rawsysrc.tests
+++ b/tests/57-basic-rawsysrc.tests
@@ -1,0 +1,11 @@
+#
+# libseccomp regression test automation data
+#
+# Copyright (c) 2020 Cisco Systems, Inc. <pmoore2@cisco.com>
+# Author: Paul Moore <paul@paul-moore.com>
+#
+
+test type: basic
+
+# Test command
+57-basic-rawsysrc

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -95,7 +95,8 @@ check_PROGRAMS = \
 	53-sim-binary_tree \
 	54-live-binary_tree \
 	55-basic-pfc_binary_tree \
-	56-basic-iterate_syscalls
+	56-basic-iterate_syscalls \
+	57-basic-rawsysrc
 
 EXTRA_DIST_TESTPYTHON = \
 	util.py \
@@ -210,7 +211,8 @@ EXTRA_DIST_TESTCFGS = \
 	53-sim-binary_tree.tests \
 	54-live-binary_tree.tests \
 	55-basic-pfc_binary_tree.tests \
-	56-basic-iterate_syscalls.tests
+	56-basic-iterate_syscalls.tests \
+	57-basic-rawsysrc.tests
 
 EXTRA_DIST_TESTSCRIPTS = \
 	38-basic-pfc_coverage.sh 38-basic-pfc_coverage.pfc \

--- a/tests/util.c
+++ b/tests/util.c
@@ -200,14 +200,14 @@ int util_file_write(const char *path)
 
 	fd = open(path, O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR);
 	if (fd < 0)
-		return errno;
+		return -errno;
 	if (write(fd, buf, buf_len) < buf_len) {
-		int rc = errno;
+		int rc = -errno;
 		close(fd);
 		return rc;
 	}
 	if (close(fd) < 0)
-		return errno;
+		return -errno;
 
 	return 0;
 }

--- a/tools/scmp_bpf_disasm.c
+++ b/tools/scmp_bpf_disasm.c
@@ -288,7 +288,7 @@ static void bpf_decode_args(const bpf_instr_raw *bpf, unsigned int line)
  * @param file the BPF program
  *
  * Read the BPF program and display the instructions.  Returns zero on success,
- * negative values on failure.
+ * non-zero values on failure.
  *
  */
 static int bpf_decode(FILE *file)
@@ -424,7 +424,7 @@ static void bpf_dot_decode_args(const bpf_instr_raw *bpf, unsigned int line)
  * @param file the BPF program
  *
  * Read the BPF program and display the instructions.  Returns zero on success,
- * negative values on failure.
+ * non-zero values on failure.
  *
  */
 static int bpf_dot_decode(FILE *file)


### PR DESCRIPTION
This has already been covered in detail in issue #97 so I won't repeat the details here.  In summary, this PR establishes the APIs error codes as part of the API from here moving forwards.