### PR TITLE
RFE: rename hash() to seccomp_hash() to resolve name collisions when static linking

### DIFF
--- a/src/gen_bpf.c
+++ b/src/gen_bpf.c
@@ -578,10 +578,10 @@ static int _hsh_add(struct bpf_state *state, struct bpf_blk **blk_p,
 		return -ENOMEM;
 
 	/* generate the hash */
-	h_val_tmp[0] = hash(blk->blks, _BLK_MSZE(blk));
-	h_val_tmp[1] = hash(&blk->acc_start, sizeof(blk->acc_start));
-	h_val_tmp[2] = hash(&blk->acc_end, sizeof(blk->acc_end));
-	h_val = hash(h_val_tmp, sizeof(h_val_tmp));
+	h_val_tmp[0] = seccomp_hash(blk->blks, _BLK_MSZE(blk));
+	h_val_tmp[1] = seccomp_hash(&blk->acc_start, sizeof(blk->acc_start));
+	h_val_tmp[2] = seccomp_hash(&blk->acc_end, sizeof(blk->acc_end));
+	h_val = seccomp_hash(h_val_tmp, sizeof(h_val_tmp));
 	blk->hash = h_val;
 	blk->flag_hash = true;
 	blk->node = NULL;

--- a/src/hash.c
+++ b/src/hash.c
@@ -38,7 +38,7 @@ static inline uint32_t fmix32(uint32_t h)
 }
 
 /* NOTE: this is an implementation of MurmurHash3_x86_32 */
-uint32_t hash(const void *key, size_t length)
+uint32_t seccomp_hash(const void *key, size_t length)
 {
 	const uint8_t *data = (const uint8_t *)key;
 	const uint32_t *blocks;

--- a/src/hash.h
+++ b/src/hash.h
@@ -10,7 +10,7 @@
 
 #include <inttypes.h>
 
-uint32_t hash(const void *key, size_t length);
+uint32_t seccomp_hash(const void *key, size_t length);
 
 #endif
 


### PR DESCRIPTION
Since hash() is exposed as a strong symbol, it may lead to link-time
errors when another library defines the same function called `hash()`.
This patch fixes the issue by adding a `seccomp_` prefix.

Testing done: `make check`