### PR TITLE
RFE: cleanup the syscalls.csv format

### DIFF
--- a/src/arch-syscall-validate
+++ b/src/arch-syscall-validate
@@ -733,12 +733,8 @@ function gen_csv() {
 		   done) | awk -F "," '{ print $1 }' | sort -u)
 
 	# output a simple header
-	printf "# libseccomp syscall table\n"
-	printf "#\n"
-	printf "# kernel: %s (%s)\n" \
-		"$(kernel_version "$1")" "$(TZ=UTC date -R)"
-	printf "#\n"
-	printf "#syscall"
+	printf "#syscall (v%s %s)" \
+		"$(kernel_version "$1")" "$(TZ=UTC date "+%Y-%m-%d")"
 	for abi in $abi_list; do
 		printf ",%s" $abi
 	done

--- a/src/syscalls.csv
+++ b/src/syscalls.csv
@@ -1,8 +1,4 @@
-# libseccomp syscall table
-#
-# kernel: 5.6.0 (Mon, 11 May 2020 04:28:57 +0000)
-#
-#syscall,x86,x86_64,x32,arm,aarch64,mips,mips64,mips64n32,parisc,parisc64,ppc,ppc64,riscv64,s390,s390x
+#syscall (v5.7.0 2020-06-14),x86,x86_64,x32,arm,aarch64,mips,mips64,mips64n32,parisc,parisc64,ppc,ppc64,riscv64,s390,s390x
 accept,PNR,43,43,285,202,168,42,42,35,35,330,330,202,PNR,PNR
 accept4,364,288,288,366,242,334,293,297,320,320,344,344,242,364,364
 access,33,21,21,33,PNR,33,20,20,33,33,33,33,PNR,33,33


### PR DESCRIPTION
This should provide a nice clean display in the GitHub CSV viewer.

Signed-off-by: Paul Moore <paul@paul-moore.com>