### PR TITLE
BUG: don't return a bogus pointer when gen_bpf_generate() fails

### DIFF
--- a/src/gen_bpf.c
+++ b/src/gen_bpf.c
@@ -1968,6 +1968,8 @@ struct bpf_program *gen_bpf_generate(const struct db_filter_col *col)
 	rc = _gen_bpf_build_bpf(&state, col);
 	if (rc == 0)
 		state.bpf = NULL;
+	else
+		prgm = NULL;
 	_state_release(&state);
 
 	return prgm;


### PR DESCRIPTION
In the case where gen_bpf_generate() fails due to a
_gen_bpf_build_bpf() failure we were returning a pointer to a BPF
program block which we had already freed - oops.  Thankfully the
fix is trivial.

Special thanks to Tudor Brindus for not only reporting the problem
but providing a very detailed root cause analysis.

Fixes: #240