### PR TITLE
RFE: clarify that syscall must exist in all filter architectures

### DIFF
--- a/doc/man/man3/seccomp_rule_add.3
+++ b/doc/man/man3/seccomp_rule_add.3
@@ -140,6 +140,9 @@ rule, you can only compare each argument once in a single rule.  In other words,
 you can not have multiple comparisons of the 3rd syscall argument in a single
 rule.
 .P
+In a filter containing multiple architectures, it is an error to add a filter
+rule for a syscall that does not exist in all of the filter's architectures.
+.P
 While it is possible to specify the
 .I syscall
 value directly using the standard


### PR DESCRIPTION
If a syscall is used in a multi-architecture filter, the syscall must
exist in all the architectures, or -EOPNOTSUPP is returned. For example,
epoll_wait_old has value 215 in x86-64, but does not exist in x86.
Trying to add it in an x86-64/x86 filter will fail.

This commit clarifies that libseccomp will reject a rule containing such
a case.

I suppose an alternative here might be to add the rule in all the
architectures where it's valid and only return -EOPNOTSUPP if the syscall
is invalid in *all* architectures, but I think just documenting the behavior
is probably enough &mdash; though the latter might be a bit more
ergonomic.