### PR TITLE
BUG: the seccomp_attr_get/set(3) manpages do not document SCMP_FLTATR_CTL_OPTIMIZE

### DIFF
--- a/doc/man/man3/seccomp_attr_set.3
+++ b/doc/man/man3/seccomp_attr_set.3
@@ -101,6 +101,32 @@ Defaults to off (
 .I value
 == 0).
 .TP
+.B SCMP_FLTATR_CTL_OPTIMIZE
+A flag to specify the optimization level of the seccomp filter.  By default
+libseccomp generates a set of sequential \'if\' statements for each rule in
+the filter.
+.BR seccomp_syscall_priority(3)
+can be used to prioritize the order for the default cause.  The binary tree
+optimization sorts by syscall numbers and generates consistent
+.BR O(log\ n)
+filter traversal for every rule in the filter.  The binary tree may be
+advantageous for large filters.  Note that
+.BR seccomp_syscall_priority(3)
+is ignored when SCMP_FLTATR_CTL_OPTIMIZE == 2.
+.RS
+.P
+The different optimization levels are described below:
+.TP
+.B 0
+Reserved value, not currently used.
+.TP
+.B 1
+Rules sorted by priority and complexity (DEFAULT).
+.TP
+.B 2
+Binary tree sorted by syscall number.
+.RE
+.TP
 .B SCMP_FLTATR_API_SYSRAWRC
 A flag to specify if libseccomp should pass system error codes back to the
 caller instead of the default -ECANCELED.  Defaults to off (


### PR DESCRIPTION
This commit documents the usage of SCMP_FLTATR_CTL_OPTIMIZE in the seccomp_attr_set.3 man page.

Addresses Issue #245 