### PR TITLE
RFE: add support for openat2 to the release-2.4 branch

### DIFF
--- a/include/seccomp-syscalls.h
+++ b/include/seccomp-syscalls.h
@@ -273,6 +273,7 @@
 #define __PNR_timerfd_settime64			-10239
 #define __PNR_utimensat_time64			-10240
 #define __PNR_ppoll				-10241
+#define __PNR_openat2				-10242
 
 /*
  * libseccomp syscall definitions
@@ -1285,6 +1286,12 @@
 #endif
 
 #define __SNR_openat			__NR_openat
+
+#ifdef __NR_openat2
+#define __SNR_openat2			__NR_openat2
+#else
+#define __SNR_openat2			__PNR_openat2
+#endif
 
 #ifdef __NR_pause
 #define __SNR_pause			__NR_pause

--- a/src/arch-aarch64-syscalls.c
+++ b/src/arch-aarch64-syscalls.c
@@ -266,6 +266,7 @@ const struct arch_syscall_def aarch64_syscall_table[] = { \
 	{ "open_by_handle_at", 265 },
 	{ "open_tree", 428 },
 	{ "openat", 56 },
+	{ "openat2", 437 },
 	{ "pause", __PNR_pause },
 	{ "pciconfig_iobase", __PNR_pciconfig_iobase },
 	{ "pciconfig_read", __PNR_pciconfig_read },

--- a/src/arch-arm-syscalls.c
+++ b/src/arch-arm-syscalls.c
@@ -278,6 +278,7 @@ const struct arch_syscall_def arm_syscall_table[] = { \
 	{ "open_by_handle_at", (__SCMP_NR_BASE + 371) },
 	{ "open_tree", (__SCMP_NR_BASE + 428) },
 	{ "openat", (__SCMP_NR_BASE + 322) },
+	{ "openat2", (__SCMP_NR_BASE + 437) },
 	{ "pause", (__SCMP_NR_BASE + 29) },
 	{ "pciconfig_iobase", (__SCMP_NR_BASE + 271) },
 	{ "pciconfig_read", (__SCMP_NR_BASE + 272) },

--- a/src/arch-mips-syscalls.c
+++ b/src/arch-mips-syscalls.c
@@ -270,6 +270,7 @@ const struct arch_syscall_def mips_syscall_table[] = { \
 	{ "open_by_handle_at", (__SCMP_NR_BASE + 340) },
 	{ "open_tree", (__SCMP_NR_BASE + 428) },
 	{ "openat", (__SCMP_NR_BASE + 288) },
+	{ "openat2", (__SCMP_NR_BASE + 437) },
 	{ "pause", (__SCMP_NR_BASE + 29) },
 	{ "pciconfig_iobase", __PNR_pciconfig_iobase },
 	{ "pciconfig_read", __PNR_pciconfig_read },

--- a/src/arch-mips64-syscalls.c
+++ b/src/arch-mips64-syscalls.c
@@ -270,6 +270,7 @@ const struct arch_syscall_def mips64_syscall_table[] = { \
 	{ "open_by_handle_at", (__SCMP_NR_BASE + 299) },
 	{ "open_tree", (__SCMP_NR_BASE + 428) },
 	{ "openat", (__SCMP_NR_BASE + 247) },
+	{ "openat2", (__SCMP_NR_BASE + 437) },
 	{ "pause", (__SCMP_NR_BASE + 33) },
 	{ "pciconfig_iobase", __PNR_pciconfig_iobase },
 	{ "pciconfig_read", __PNR_pciconfig_read },

--- a/src/arch-mips64n32-syscalls.c
+++ b/src/arch-mips64n32-syscalls.c
@@ -270,6 +270,7 @@ const struct arch_syscall_def mips64n32_syscall_table[] = { \
 	{ "open_by_handle_at", (__SCMP_NR_BASE + 304) },
 	{ "open_tree", (__SCMP_NR_BASE + 428) },
 	{ "openat", (__SCMP_NR_BASE + 251) },
+	{ "openat2", (__SCMP_NR_BASE + 437) },
 	{ "pause", (__SCMP_NR_BASE + 33) },
 	{ "pciconfig_iobase", __PNR_pciconfig_iobase },
 	{ "pciconfig_read", __PNR_pciconfig_read },

--- a/src/arch-parisc-syscalls.c
+++ b/src/arch-parisc-syscalls.c
@@ -250,6 +250,7 @@ const struct arch_syscall_def parisc_syscall_table[] = { \
 	{ "open_by_handle_at",	326 },
 	{ "open_tree", __PNR_open_tree },
 	{ "openat",	275 },
+	{ "openat2", 437 },
 	{ "pause",	29 },
 	{ "pciconfig_iobase", __PNR_pciconfig_iobase },
 	{ "pciconfig_read", __PNR_pciconfig_read },

--- a/src/arch-ppc-syscalls.c
+++ b/src/arch-ppc-syscalls.c
@@ -267,6 +267,7 @@ const struct arch_syscall_def ppc_syscall_table[] = { \
 	{ "open_by_handle_at", 346 },
 	{ "open_tree", 428 },
 	{ "openat", 286 },
+	{ "openat2", 437 },
 	{ "pause", 29 },
 	{ "pciconfig_iobase", 200 },
 	{ "pciconfig_read", 198 },

--- a/src/arch-ppc64-syscalls.c
+++ b/src/arch-ppc64-syscalls.c
@@ -267,6 +267,7 @@ const struct arch_syscall_def ppc64_syscall_table[] = { \
 	{ "open_by_handle_at", 346 },
 	{ "open_tree", 428 },
 	{ "openat", 286 },
+	{ "openat2", 437 },
 	{ "pause", 29 },
 	{ "pciconfig_iobase", 200 },
 	{ "pciconfig_read", 198 },

--- a/src/arch-s390-syscalls.c
+++ b/src/arch-s390-syscalls.c
@@ -250,6 +250,7 @@ const struct arch_syscall_def s390_syscall_table[] = { \
 	{ "open_by_handle_at", 336 },
 	{ "open_tree", 428 },
 	{ "openat", 288 },
+	{ "openat2", 437 },
 	{ "pause", 29 },
 	{ "pciconfig_iobase", __PNR_pciconfig_iobase },
 	{ "pciconfig_read", __PNR_pciconfig_read },

--- a/src/arch-s390x-syscalls.c
+++ b/src/arch-s390x-syscalls.c
@@ -250,6 +250,7 @@ const struct arch_syscall_def s390x_syscall_table[] = { \
 	{ "open_by_handle_at", 336 },
 	{ "open_tree", 428 },
 	{ "openat", 288 },
+	{ "openat2", 437 },
 	{ "pause", 29 },
 	{ "pciconfig_iobase", __PNR_pciconfig_iobase },
 	{ "pciconfig_read", __PNR_pciconfig_read },

--- a/src/arch-x32-syscalls.c
+++ b/src/arch-x32-syscalls.c
@@ -266,6 +266,7 @@ const struct arch_syscall_def x32_syscall_table[] = { \
 	{ "open_by_handle_at", (X32_SYSCALL_BIT + 304) },
 	{ "open_tree", (X32_SYSCALL_BIT + 428) },
 	{ "openat", (X32_SYSCALL_BIT + 257) },
+	{ "openat2", (X32_SYSCALL_BIT + 437) },
 	{ "pause", (X32_SYSCALL_BIT + 34) },
 	{ "pciconfig_iobase", __PNR_pciconfig_iobase },
 	{ "pciconfig_read", __PNR_pciconfig_read },

--- a/src/arch-x86-syscalls.c
+++ b/src/arch-x86-syscalls.c
@@ -266,6 +266,7 @@ const struct arch_syscall_def x86_syscall_table[] = { \
 	{ "open_by_handle_at", 342 },
 	{ "open_tree", 428 },
 	{ "openat", 295 },
+	{ "openat2", 437 },
 	{ "pause", 29 },
 	{ "pciconfig_iobase", __PNR_pciconfig_iobase },
 	{ "pciconfig_read", __PNR_pciconfig_read },

--- a/src/arch-x86_64-syscalls.c
+++ b/src/arch-x86_64-syscalls.c
@@ -266,6 +266,7 @@ const struct arch_syscall_def x86_64_syscall_table[] = { \
 	{ "open_by_handle_at", 304 },
 	{ "open_tree", 428 },
 	{ "openat", 257 },
+	{ "openat2", 437 },
 	{ "pause", 34 },
 	{ "pciconfig_iobase", __PNR_pciconfig_iobase },
 	{ "pciconfig_read", __PNR_pciconfig_read },


### PR DESCRIPTION
I'm not sure what exactly is the purpose of `include/seccomp-syscalls.h` and what are the `__PNR_`/`__SNR_` prefixes for, so I may have gotten that wrong.

Tests pass on x86_64. Not sure if new tests are needed.