### PR TITLE
BUG: undefine "mips" to prevent build problems for MIPS targets

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -65,9 +65,11 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 dnl ####
 dnl build flags
+dnl NOTE: the '-Umips' is here because MIPS GCC compilers "helpfully" define it
+dnl       for us which wreaks havoc on the build
 dnl ####
 AM_CPPFLAGS="-I\${top_srcdir}/include -I\${top_builddir}/include"
-AM_CFLAGS="-Wall"
+AM_CFLAGS="-Wall -Umips"
 AM_LDFLAGS="-Wl,-z -Wl,relro"
 AC_SUBST([AM_CPPFLAGS])
 AC_SUBST([AM_CFLAGS])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -61,7 +61,7 @@ lib_LTLIBRARIES = libseccomp.la
 arch_syscall_dump_SOURCES = arch-syscall-dump.c ${SOURCES_ALL}
 
 arch_syscall_check_SOURCES = arch-syscall-check.c ${SOURCES_ALL}
-arch_syscall_check_CFLAGS = ${CODE_COVERAGE_CFLAGS}
+arch_syscall_check_CFLAGS = ${AM_CFLAGS} ${CODE_COVERAGE_CFLAGS}
 arch_syscall_check_LDFLAGS = ${CODE_COVERAGE_LDFLAGS}
 
 libseccomp_la_SOURCES = ${SOURCES_ALL}


### PR DESCRIPTION
It turns out that the MIPS GCC compiler defines a "mips" cpp macro
which was resulting in build failures on MIPS so we need to
undefine the "mips" macro during build.  As this should be safe
to do in all architectures, just add it to the compiler flags by
default.

This was reported in the following GH issue:
* https://github.com/seccomp/libseccomp/issues/274

Reported-by: Rongwei Zhang <pudh4418@gmail.com>
Suggested-by: Rongwei Zhang <pudh4418@gmail.com>
Signed-off-by: Paul Moore <paul@paul-moore.com>