### PR TITLE
BUG: change our internal handling of the notification fd

### DIFF
--- a/doc/man/man3/seccomp_init.3
+++ b/doc/man/man3/seccomp_init.3
@@ -36,7 +36,15 @@ The
 function releases the existing filter context state before reinitializing it
 and can only be called after a call to
 .BR seccomp_init ()
-has succeeded.
+has succeeded.  If
+.BR seccomp_reset ()
+is called with a NULL filter, it resets the library's global task state;
+normally this is not needed, but it may be required to continue using the
+library after a
+.BR fork ()
+or
+.BR clone ()
+call to ensure the API level and user notification state is properly reset.
 .P
 When the caller is finished configuring the seccomp filter and has loaded it
 into the kernel, the caller should call

--- a/doc/man/man3/seccomp_init.3
+++ b/doc/man/man3/seccomp_init.3
@@ -38,8 +38,10 @@ and can only be called after a call to
 .BR seccomp_init ()
 has succeeded.  If
 .BR seccomp_reset ()
-is called with a NULL filter, it resets the library's global task state;
-normally this is not needed, but it may be required to continue using the
+is called with a NULL filter, it resets the library's global task state,
+including any notification file descriptors retrieved by
+.BR seccomp_notify_fd(3) .
+Normally this is not needed, but it may be required to continue using the
 library after a
 .BR fork ()
 or

--- a/doc/man/man3/seccomp_notify_alloc.3
+++ b/doc/man/man3/seccomp_notify_alloc.3
@@ -59,7 +59,8 @@ returns the notification fd of a filter after it has been loaded.
 .\" //////////////////////////////////////////////////////////////////////////
 The
 .BR seccomp_notify_fd ()
-returns the notification fd of the loaded filter.
+returns the notification fd of the loaded filter, -1 if a notification fd has
+not yet been created, and -EINVAL if the filter context is invalid.
 .P
 The
 .BR seccomp_notify_id_valid ()

--- a/src/db.c
+++ b/src/db.c
@@ -1057,7 +1057,6 @@ int db_col_reset(struct db_filter_col *col, uint32_t def_action)
 	if (col->filters)
 		free(col->filters);
 	col->filters = NULL;
-	col->notify_fd = -1;
 
 	/* set the endianess to undefined */
 	col->endian = 0;

--- a/src/db.h
+++ b/src/db.h
@@ -160,8 +160,7 @@ struct db_filter_col {
 	/* transaction snapshots */
 	struct db_filter_snap *snapshots;
 
-	/* notification fd that was returned from seccomp() */
-	int notify_fd;
+	/* userspace notification */
 	bool notify_used;
 };
 

--- a/src/system.h
+++ b/src/system.h
@@ -182,6 +182,8 @@ struct seccomp_notif_resp {
 #define SECCOMP_IOCTL_NOTIF_ID_VALID    SECCOMP_IOR(2, __u64)
 #endif /* SECCOMP_RET_USER_NOTIF */
 
+void sys_reset_state(void);
+
 int sys_chk_seccomp_syscall(void);
 void sys_set_seccomp_syscall(bool enable);
 
@@ -193,6 +195,7 @@ void sys_set_seccomp_flag(int flag, bool enable);
 
 int sys_filter_load(struct db_filter_col *col, bool rawrc);
 
+int sys_notify_fd(void);
 int sys_notify_alloc(struct seccomp_notif **req,
 		     struct seccomp_notif_resp **resp);
 int sys_notify_receive(int fd, struct seccomp_notif *req);

--- a/tests/11-basic-basic_errors.c
+++ b/tests/11-basic-basic_errors.c
@@ -41,12 +41,9 @@ int main(int argc, char *argv[])
 	seccomp_release(ctx);
 	ctx = NULL;
 
-	/* seccomp_reset error */
-	rc = seccomp_reset(ctx, SCMP_ACT_KILL + 1);
-	if (rc != -EINVAL)
-		return -1;
-	rc = seccomp_reset(ctx, SCMP_ACT_KILL);
-	if (rc != -EINVAL)
+	/* ensure that seccomp_reset(NULL, ...) is accepted */
+	rc = seccomp_reset(NULL, SCMP_ACT_ALLOW);
+	if (rc != 0)
 		return -1;
 
 	/* seccomp_load error */

--- a/tests/51-live-user_notification.c
+++ b/tests/51-live-user_notification.c
@@ -99,6 +99,27 @@ int main(int argc, char *argv[])
 		goto out;
 	}
 
+	rc = seccomp_reset(ctx, SCMP_ACT_ALLOW);
+	if (rc < 0)
+		goto out;
+
+	rc = seccomp_rule_add(ctx, SCMP_ACT_NOTIFY, SCMP_SYS(getppid), 0, NULL);
+	if (rc)
+		goto out;
+
+	rc  = seccomp_load(ctx);
+	if (rc < 0)
+		goto out;
+
+	rc = seccomp_notify_fd(ctx);
+	if (rc < 0)
+		goto out;
+	if (rc != fd) {
+		rc = -EFAULT;
+		goto out;
+	} else
+		rc = 0;
+
 out:
 	if (fd >= 0)
 		close(fd);

--- a/tests/51-live-user_notification.py
+++ b/tests/51-live-user_notification.py
@@ -52,6 +52,10 @@ def test():
             raise RuntimeError("Child process error")
         if os.WEXITSTATUS(rc) != 0:
             raise RuntimeError("Child process error")
+        f.reset(ALLOW)
+        f.add_rule(NOTIFY, "getppid")
+        f.load()
+        # no easy way to check the notification fd here
         quit(160)
 
 test()


### PR DESCRIPTION
**UPDATE:** In addition to the original patch (the descrption of which is below), this PR also contains a patch which only requests the notification fd if the filter requires it.  The patch also changes the behavior of `seccomp_reset(NULL, ...)` so that is closes the notification fd.  See the individual patches/commits for more information.

It turns out that requesting the seccomp userspace notifcation fd
more than once is a bad thing which causes the kernel to complain
(rightfully so for a variety of reasons).  Unfortunately as we were
always requesting the notification fd whenever possible this results
in problems at filter load time.

Our solution is to move the notification fd out of the filter context
and into the global task context, using a newly created task_state
structure.  This allows us to store, and retrieve the notification
outside the scope of an individual filter context.  It also provides
some implementation improvements by giving us a convenient place to
stash all of the API level related support variables.  We also extend
the seccomp_reset() API call to reset this internal global state when
passed a NULL filter context.

There is one potential case which we don't currently handle well:
threads.  At the moment libseccomp is thread ignorant, and that works
well as the only global state up to this point was the currently
supported API level information which was common to all threads in a
process.  Unfortunately, it appears that the notification fd need not
be common to all threads in a process, yet this patch treats it as if
it is common.  I suspect this is a very unusual use case so I decided
to keep this patch simple and ignore this case, but in the future if
we need to support this properly we should be able to do so without
API changes by keeping an internal list of notification fds indexed
by gettid(2).

This fixes the GitHub issue below:
* https://github.com/seccomp/libseccomp/issues/273

Reported-by: Tobias Stoeckmann <tobias@stoeckmann.org>
Signed-off-by: Paul Moore <paul@paul-moore.com>