### PR TITLE
BUG: store syscall numbers directly

### DIFF
--- a/src/arch-arm.c
+++ b/src/arch-arm.c
@@ -26,58 +26,13 @@
 #include "arch.h"
 #include "arch-arm.h"
 
-#define __SCMP_NR_OABI_SYSCALL_BASE     0x900000
-#define __SCMP_ARM_NR_BASE              0x0f0000
-
-/* NOTE: we currently only support the ARM EABI, more info at the URL below:
- *       -> http://wiki.embeddedarm.com/wiki/EABI_vs_OABI */
-#if 1
-#define __SCMP_NR_BASE                  0
-#else
-#define __SCMP_NR_BASE                  __SCMP_NR_OABI_SYSCALL_BASE
-#endif
-
-/**
- * Resolve a syscall name to a number
- * @param name the syscall name
- *
- * Resolve the given syscall name to the syscall number using the syscall table.
- * Returns the syscall number on success, including negative pseudo syscall
- * numbers; returns __NR_SCMP_ERROR on failure.
- *
- */
-int arm_syscall_resolve_name_munge(const char *name)
-{
-	int sys;
-
-	sys = arm_syscall_resolve_name(name);
-	if (sys == __NR_SCMP_ERROR)
-		return sys;
-
-	return (sys | __SCMP_NR_BASE);
-}
-
-/**
- * Resolve a syscall number to a name
- * @param num the syscall number
- *
- * Resolve the given syscall number to the syscall name using the syscall table.
- * Returns a pointer to the syscall name string on success, including pseudo
- * syscall names; returns NULL on failure.
- *
- */
-const char *arm_syscall_resolve_num_munge(int num)
-{
-	return arm_syscall_resolve_num(num & (~__SCMP_NR_BASE));
-}
-
 const struct arch_def arch_def_arm = {
 	.token = SCMP_ARCH_ARM,
 	.token_bpf = AUDIT_ARCH_ARM,
 	.size = ARCH_SIZE_32,
 	.endian = ARCH_ENDIAN_LITTLE,
-	.syscall_resolve_name = arm_syscall_resolve_name_munge,
-	.syscall_resolve_num = arm_syscall_resolve_num_munge,
+	.syscall_resolve_name = arm_syscall_resolve_name,
+	.syscall_resolve_num = arm_syscall_resolve_num,
 	.syscall_rewrite = NULL,
 	.rule_add = NULL,
 };

--- a/src/arch-gperf-generate
+++ b/src/arch-gperf-generate
@@ -22,10 +22,15 @@ gperf_tmpl=$2
 sys_csv_tmp=$(mktemp -t generate_syscalls_XXXXXX)
 
 # filter and prepare the syscall csv file
-cat $sys_csv | grep -v '^#' | nl -ba -s, -v0 | \
-    sed -e 's/^[[:space:]]\+\([0-9]\+\),\([^,]\+\),\(.*\)/\2,\1,\3/' \
-        -e ':repeat; {s|\([^,]\+\)\(.*\)[^_]PNR|\1\2,__PNR_\1|g;}; t repeat' \
-         > $sys_csv_tmp
+awk -vFS=, -vOFS=, -vn=0 '/^[^#]/ {
+  if ($4 != "PNR") { $4 = "0x40000000|"$4; } # x32
+  if ($7 != "PNR") { $7 = 4000+$7; }         # mips
+  if ($8 != "PNR") { $8 = 5000+$8; }         # mips64
+  if ($9 != "PNR") { $9 = 6000+$9; }         # mips64n32
+  $2 = n++ OFS $2;
+  gsub("PNR", "__PNR_" $1);
+  print
+}' $sys_csv > $sys_csv_tmp
 [[ $? -ne 0 ]] && exit 1
 
 # create the gperf file

--- a/src/arch-mips.c
+++ b/src/arch-mips.c
@@ -27,50 +27,13 @@
 #include "arch.h"
 #include "arch-mips.h"
 
-/* O32 ABI */
-#define __SCMP_NR_BASE			4000
-
-/**
- * Resolve a syscall name to a number
- * @param name the syscall name
- *
- * Resolve the given syscall name to the syscall number using the syscall table.
- * Returns the syscall number on success, including negative pseudo syscall
- * numbers; returns __NR_SCMP_ERROR on failure.
- *
- */
-int mips_syscall_resolve_name_munge(const char *name)
-{
-	int sys;
-
-	sys = mips_syscall_resolve_name(name);
-	if (sys == __NR_SCMP_ERROR)
-		return sys;
-
-	return sys + __SCMP_NR_BASE;
-}
-
-/**
- * Resolve a syscall number to a name
- * @param num the syscall number
- *
- * Resolve the given syscall number to the syscall name using the syscall table.
- * Returns a pointer to the syscall name string on success, including pseudo
- * syscall names; returns NULL on failure.
- *
- */
-const char *mips_syscall_resolve_num_munge(int num)
-{
-	return mips_syscall_resolve_num(num - __SCMP_NR_BASE);
-}
-
 const struct arch_def arch_def_mips = {
 	.token = SCMP_ARCH_MIPS,
 	.token_bpf = AUDIT_ARCH_MIPS,
 	.size = ARCH_SIZE_32,
 	.endian = ARCH_ENDIAN_BIG,
-	.syscall_resolve_name = mips_syscall_resolve_name_munge,
-	.syscall_resolve_num = mips_syscall_resolve_num_munge,
+	.syscall_resolve_name = mips_syscall_resolve_name,
+	.syscall_resolve_num = mips_syscall_resolve_num,
 	.syscall_rewrite = NULL,
 	.rule_add = NULL,
 };
@@ -80,8 +43,8 @@ const struct arch_def arch_def_mipsel = {
 	.token_bpf = AUDIT_ARCH_MIPSEL,
 	.size = ARCH_SIZE_32,
 	.endian = ARCH_ENDIAN_LITTLE,
-	.syscall_resolve_name = mips_syscall_resolve_name_munge,
-	.syscall_resolve_num = mips_syscall_resolve_num_munge,
+	.syscall_resolve_name = mips_syscall_resolve_name,
+	.syscall_resolve_num = mips_syscall_resolve_num,
 	.syscall_rewrite = NULL,
 	.rule_add = NULL,
 };

--- a/src/arch-mips64.c
+++ b/src/arch-mips64.c
@@ -25,50 +25,13 @@
 #include "arch.h"
 #include "arch-mips64.h"
 
-/* 64 ABI */
-#define __SCMP_NR_BASE			5000
-
-/**
- * Resolve a syscall name to a number
- * @param name the syscall name
- *
- * Resolve the given syscall name to the syscall number using the syscall table.
- * Returns the syscall number on success, including negative pseudo syscall
- * numbers; returns __NR_SCMP_ERROR on failure.
- *
- */
-int mips64_syscall_resolve_name_munge(const char *name)
-{
-	int sys;
-
-	sys = mips64_syscall_resolve_name(name);
-	if (sys == __NR_SCMP_ERROR)
-		return sys;
-
-	return sys + __SCMP_NR_BASE;
-}
-
-/**
- * Resolve a syscall number to a name
- * @param num the syscall number
- *
- * Resolve the given syscall number to the syscall name using the syscall table.
- * Returns a pointer to the syscall name string on success, including pseudo
- * syscall names; returns NULL on failure.
- *
- */
-const char *mips64_syscall_resolve_num_munge(int num)
-{
-	return mips64_syscall_resolve_num(num - __SCMP_NR_BASE);
-}
-
 const struct arch_def arch_def_mips64 = {
 	.token = SCMP_ARCH_MIPS64,
 	.token_bpf = AUDIT_ARCH_MIPS64,
 	.size = ARCH_SIZE_64,
 	.endian = ARCH_ENDIAN_BIG,
-	.syscall_resolve_name = mips64_syscall_resolve_name_munge,
-	.syscall_resolve_num = mips64_syscall_resolve_num_munge,
+	.syscall_resolve_name = mips64_syscall_resolve_name,
+	.syscall_resolve_num = mips64_syscall_resolve_num,
 	.syscall_rewrite = NULL,
 	.rule_add = NULL,
 };
@@ -78,8 +41,8 @@ const struct arch_def arch_def_mipsel64 = {
 	.token_bpf = AUDIT_ARCH_MIPSEL64,
 	.size = ARCH_SIZE_64,
 	.endian = ARCH_ENDIAN_LITTLE,
-	.syscall_resolve_name = mips64_syscall_resolve_name_munge,
-	.syscall_resolve_num = mips64_syscall_resolve_num_munge,
+	.syscall_resolve_name = mips64_syscall_resolve_name,
+	.syscall_resolve_num = mips64_syscall_resolve_num,
 	.syscall_rewrite = NULL,
 	.rule_add = NULL,
 };

--- a/src/arch-mips64n32.c
+++ b/src/arch-mips64n32.c
@@ -27,50 +27,13 @@
 #include "arch.h"
 #include "arch-mips64n32.h"
 
-/* N32 ABI */
-#define __SCMP_NR_BASE			6000
-
-/**
- * Resolve a syscall name to a number
- * @param name the syscall name
- *
- * Resolve the given syscall name to the syscall number using the syscall table.
- * Returns the syscall number on success, including negative pseudo syscall
- * numbers; returns __NR_SCMP_ERROR on failure.
- *
- */
-int mips64n32_syscall_resolve_name_munge(const char *name)
-{
-	int sys;
-
-	sys = mips64n32_syscall_resolve_name(name);
-	if (sys == __NR_SCMP_ERROR)
-		return sys;
-
-	return sys + __SCMP_NR_BASE;
-}
-
-/**
- * Resolve a syscall number to a name
- * @param num the syscall number
- *
- * Resolve the given syscall number to the syscall name using the syscall table.
- * Returns a pointer to the syscall name string on success, including pseudo
- * syscall names; returns NULL on failure.
- *
- */
-const char *mips64n32_syscall_resolve_num_munge(int num)
-{
-	return mips64n32_syscall_resolve_num(num - __SCMP_NR_BASE);
-}
-
 const struct arch_def arch_def_mips64n32 = {
 	.token = SCMP_ARCH_MIPS64N32,
 	.token_bpf = AUDIT_ARCH_MIPS64N32,
 	.size = ARCH_SIZE_32,
 	.endian = ARCH_ENDIAN_BIG,
-	.syscall_resolve_name = mips64n32_syscall_resolve_name_munge,
-	.syscall_resolve_num = mips64n32_syscall_resolve_num_munge,
+	.syscall_resolve_name = mips64n32_syscall_resolve_name,
+	.syscall_resolve_num = mips64n32_syscall_resolve_num,
 	.syscall_rewrite = NULL,
 	.rule_add = NULL,
 };
@@ -80,8 +43,8 @@ const struct arch_def arch_def_mipsel64n32 = {
 	.token_bpf = AUDIT_ARCH_MIPSEL64N32,
 	.size = ARCH_SIZE_32,
 	.endian = ARCH_ENDIAN_LITTLE,
-	.syscall_resolve_name = mips64n32_syscall_resolve_name_munge,
-	.syscall_resolve_num = mips64n32_syscall_resolve_num_munge,
+	.syscall_resolve_name = mips64n32_syscall_resolve_name,
+	.syscall_resolve_num = mips64n32_syscall_resolve_num,
 	.syscall_rewrite = NULL,
 	.rule_add = NULL,
 };

--- a/src/arch-x32.c
+++ b/src/arch-x32.c
@@ -26,48 +26,14 @@
 #include "arch.h"
 #include "arch-x32.h"
 
-/**
- * Resolve a syscall name to a number
- * @param name the syscall name
- *
- * Resolve the given syscall name to the syscall number using the syscall table.
- * Returns the syscall number on success, including negative pseudo syscall
- * numbers; returns __NR_SCMP_ERROR on failure.
- *
- */
-int x32_syscall_resolve_name_munge(const char *name)
-{
-	int sys;
-
-	sys = x32_syscall_resolve_name(name);
-	if (sys == __NR_SCMP_ERROR)
-		return sys;
-
-	return (sys | X32_SYSCALL_BIT);
-}
-
-/**
- * Resolve a syscall number to a name
- * @param num the syscall number
- *
- * Resolve the given syscall number to the syscall name using the syscall table.
- * Returns a pointer to the syscall name string on success, including pseudo
- * syscall names; returns NULL on failure.
- *
- */
-const char *x32_syscall_resolve_num_munge(int num)
-{
-	return x32_syscall_resolve_num(num & (~X32_SYSCALL_BIT));
-}
-
 const struct arch_def arch_def_x32 = {
 	.token = SCMP_ARCH_X32,
 	/* NOTE: this seems odd but the kernel treats x32 like x86_64 here */
 	.token_bpf = AUDIT_ARCH_X86_64,
 	.size = ARCH_SIZE_32,
 	.endian = ARCH_ENDIAN_LITTLE,
-	.syscall_resolve_name = x32_syscall_resolve_name_munge,
-	.syscall_resolve_num = x32_syscall_resolve_num_munge,
+	.syscall_resolve_name = x32_syscall_resolve_name,
+	.syscall_resolve_num = x32_syscall_resolve_num,
 	.syscall_rewrite = NULL,
 	.rule_add = NULL,
 };


### PR DESCRIPTION
This removes the need to munge and unmunge numbers and ensures that
seccomp_rule_add can handle pseudo-syscall numbers again.

Fixes: https://github.com/seccomp/libseccomp/issues/282

Signed-off-by: Harald van Dijk <harald@gigawatt.nl>