### PR TITLE
BUG: use smaller "magic" numbers in 51-live-user_notification

### DIFF
--- a/tests/51-live-user_notification.c
+++ b/tests/51-live-user_notification.c
@@ -21,6 +21,7 @@
 
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <asm/unistd.h>
 #include <unistd.h>
 #include <seccomp.h>
 #include <signal.h>
@@ -30,15 +31,15 @@
 
 #include "util.h"
 
-#define MAGIC 0x1122334455667788UL
-
 int main(int argc, char *argv[])
 {
 	int rc, fd = -1, status;
 	struct seccomp_notif *req = NULL;
 	struct seccomp_notif_resp *resp = NULL;
 	scmp_filter_ctx ctx = NULL;
-	pid_t pid = 0;
+	pid_t pid = 0, magic;
+
+	magic = getpid();
 
 	ctx = seccomp_init(SCMP_ACT_ALLOW);
 	if (ctx == NULL)
@@ -59,7 +60,7 @@ int main(int argc, char *argv[])
 
 	pid = fork();
 	if (pid == 0)
-		exit(syscall(SCMP_SYS(getpid)) != MAGIC);
+		exit(syscall(__NR_getpid) != magic);
 
 	rc = seccomp_notify_alloc(&req, &resp);
 	if (rc)
@@ -68,7 +69,7 @@ int main(int argc, char *argv[])
 	rc = seccomp_notify_receive(fd, req);
 	if (rc)
 		goto out;
-	if (req->data.nr != SCMP_SYS(getpid)) {
+	if (req->data.nr != __NR_getpid) {
 		rc = -EFAULT;
 		goto out;
 	}
@@ -77,7 +78,7 @@ int main(int argc, char *argv[])
 		goto out;
 
 	resp->id = req->id;
-	resp->val = MAGIC;
+	resp->val = magic;
 	resp->error = 0;
 	resp->flags = 0;
 	rc = seccomp_notify_respond(fd, resp);


### PR DESCRIPTION
On an x32 based system, and perhaps other 32-bit systems, the magic
value in test 51-live-user_notification was too large and resulted
in a failed comparison even when the userspace notification mechanism
was working properly.

This patch addresses this problem by using the parent process's PID
for the magic number.  For all arches/ABIs we know it is a valid
return value for getpid() while also being one of the few PIDs that
the child process should never legitimately get from a call to
getpid().

This patch also restricts the use of SCMP_SYS() to only the
libseccomp API calls.  This should help us catch arches/ABIs that
don't implement getpid().  I'm also not sure we want to be
responsible for using SCMP_SYS() outside of the libseccomp API.

Signed-off-by: Paul Moore <paul@paul-moore.com>