### PR TITLE
BUG: ensure we don't "munge" pseudo syscall numbers

### DIFF
--- a/src/arch-arm.c
+++ b/src/arch-arm.c
@@ -50,8 +50,9 @@ int arm_syscall_resolve_name_munge(const char *name)
 {
 	int sys;
 
+	/* NOTE: we don't want to modify the pseudo-syscall numbers */
 	sys = arm_syscall_resolve_name(name);
-	if (sys == __NR_SCMP_ERROR)
+	if (sys == __NR_SCMP_ERROR || sys < 0)
 		return sys;
 
 	return (sys | __SCMP_NR_BASE);
@@ -68,7 +69,10 @@ int arm_syscall_resolve_name_munge(const char *name)
  */
 const char *arm_syscall_resolve_num_munge(int num)
 {
-	return arm_syscall_resolve_num(num & (~__SCMP_NR_BASE));
+	/* NOTE: we don't want to modify the pseudo-syscall numbers */
+	if (num >= 0)
+		num &= ~__SCMP_NR_BASE;
+	return arm_syscall_resolve_num(num);
 }
 
 const struct arch_def arch_def_arm = {

--- a/src/arch-mips.c
+++ b/src/arch-mips.c
@@ -43,8 +43,9 @@ int mips_syscall_resolve_name_munge(const char *name)
 {
 	int sys;
 
+	/* NOTE: we don't want to modify the pseudo-syscall numbers */
 	sys = mips_syscall_resolve_name(name);
-	if (sys == __NR_SCMP_ERROR)
+	if (sys == __NR_SCMP_ERROR || sys < 0)
 		return sys;
 
 	return sys + __SCMP_NR_BASE;
@@ -61,7 +62,10 @@ int mips_syscall_resolve_name_munge(const char *name)
  */
 const char *mips_syscall_resolve_num_munge(int num)
 {
-	return mips_syscall_resolve_num(num - __SCMP_NR_BASE);
+	/* NOTE: we don't want to modify the pseudo-syscall numbers */
+	if (num >= __SCMP_NR_BASE)
+		num -= __SCMP_NR_BASE;
+	return mips_syscall_resolve_num(num);
 }
 
 const struct arch_def arch_def_mips = {

--- a/src/arch-mips64.c
+++ b/src/arch-mips64.c
@@ -41,8 +41,9 @@ int mips64_syscall_resolve_name_munge(const char *name)
 {
 	int sys;
 
+	/* NOTE: we don't want to modify the pseudo-syscall numbers */
 	sys = mips64_syscall_resolve_name(name);
-	if (sys == __NR_SCMP_ERROR)
+	if (sys == __NR_SCMP_ERROR || sys < 0)
 		return sys;
 
 	return sys + __SCMP_NR_BASE;
@@ -59,7 +60,10 @@ int mips64_syscall_resolve_name_munge(const char *name)
  */
 const char *mips64_syscall_resolve_num_munge(int num)
 {
-	return mips64_syscall_resolve_num(num - __SCMP_NR_BASE);
+	/* NOTE: we don't want to modify the pseudo-syscall numbers */
+	if (num >= __SCMP_NR_BASE)
+		num -= __SCMP_NR_BASE;
+	return mips64_syscall_resolve_num(num);
 }
 
 const struct arch_def arch_def_mips64 = {

--- a/src/arch-mips64n32.c
+++ b/src/arch-mips64n32.c
@@ -43,8 +43,9 @@ int mips64n32_syscall_resolve_name_munge(const char *name)
 {
 	int sys;
 
+	/* NOTE: we don't want to modify the pseudo-syscall numbers */
 	sys = mips64n32_syscall_resolve_name(name);
-	if (sys == __NR_SCMP_ERROR)
+	if (sys == __NR_SCMP_ERROR || sys < 0)
 		return sys;
 
 	return sys + __SCMP_NR_BASE;
@@ -61,7 +62,10 @@ int mips64n32_syscall_resolve_name_munge(const char *name)
  */
 const char *mips64n32_syscall_resolve_num_munge(int num)
 {
-	return mips64n32_syscall_resolve_num(num - __SCMP_NR_BASE);
+	/* NOTE: we don't want to modify the pseudo-syscall numbers */
+	if (num >= __SCMP_NR_BASE)
+		num -= __SCMP_NR_BASE;
+	return mips64n32_syscall_resolve_num(num);
 }
 
 const struct arch_def arch_def_mips64n32 = {

--- a/src/arch-x32.c
+++ b/src/arch-x32.c
@@ -39,8 +39,9 @@ int x32_syscall_resolve_name_munge(const char *name)
 {
 	int sys;
 
+	/* NOTE: we don't want to modify the pseudo-syscall numbers */
 	sys = x32_syscall_resolve_name(name);
-	if (sys == __NR_SCMP_ERROR)
+	if (sys == __NR_SCMP_ERROR || sys < 0)
 		return sys;
 
 	return (sys | X32_SYSCALL_BIT);
@@ -57,7 +58,10 @@ int x32_syscall_resolve_name_munge(const char *name)
  */
 const char *x32_syscall_resolve_num_munge(int num)
 {
-	return x32_syscall_resolve_num(num & (~X32_SYSCALL_BIT));
+	/* NOTE: we don't want to modify the pseudo-syscall numbers */
+	if (num >= 0)
+		num &= ~X32_SYSCALL_BIT;
+	return x32_syscall_resolve_num(num);
 }
 
 const struct arch_def arch_def_x32 = {


### PR DESCRIPTION
A number of arches/ABIs have either syscall offsets (the MIPS
family) or specific bits (x32) which are applied to their normal
syscall numbers.  We generally handle that via "munging" in
libseccomp, and it works reasonably well.  Unfortunately we were
applying this munging process to the negative pseudo syscall
numbers as well and this was causing problems.

This patch fixes the various offset/bit arches/ABIs by not applying
the munging to the negative pseudo syscall numbers.

This resolves GH issue #284:
* https://github.com/seccomp/libseccomp/issues/284

Reported-by: Harald van Dijk <harald@gigawatt.nl>
Signed-off-by: Paul Moore <paul@paul-moore.com>