### PR TITLE
RFE: integrate codespell into our syntax checker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ addons:
       - clang
       - lcov
       - gperf
+      - astyle
+      - codespell
 
 env:
   global:

--- a/include/seccomp-syscalls.h
+++ b/include/seccomp-syscalls.h
@@ -24,7 +24,7 @@
 #endif
 
 /*
- * psuedo syscall definitions
+ * pseudo syscall definitions
  */
 
 /* socket syscalls */

--- a/include/seccomp.h.in
+++ b/include/seccomp.h.in
@@ -800,11 +800,11 @@ int seccomp_notify_fd(const scmp_filter_ctx ctx);
 int seccomp_export_pfc(const scmp_filter_ctx ctx, int fd);
 
 /**
- * Generate seccomp Berkley Packet Filter (BPF) code and export it to a file
+ * Generate seccomp Berkeley Packet Filter (BPF) code and export it to a file
  * @param ctx the filter context
  * @param fd the destination fd
  *
- * This function generates seccomp Berkley Packer Filter (BPF) code and writes
+ * This function generates seccomp Berkeley Packer Filter (BPF) code and writes
  * it to the given fd.  Returns zero on success, negative values on failure.
  *
  */

--- a/src/arch.c
+++ b/src/arch.c
@@ -116,7 +116,7 @@ int arch_valid(uint32_t arch)
 
 /**
  * Lookup the architecture definition
- * @param token the architecure token
+ * @param token the architecture token
  *
  * Return the matching architecture definition, returns NULL on failure.
  *
@@ -169,7 +169,7 @@ const struct arch_def *arch_def_lookup(uint32_t token)
 
 /**
  * Lookup the architecture definition by name
- * @param arch_name the architecure name
+ * @param arch_name the architecture name
  *
  * Return the matching architecture definition, returns NULL on failure.
  *
@@ -328,8 +328,8 @@ const char *arch_syscall_resolve_num(const struct arch_def *arch, int num)
  * @param arch the architecture definition
  * @param syscall the syscall number
  *
- * Translate the syscall number, in the context of the native architecure, to
- * the provided architecure.  Returns zero on success, negative values on
+ * Translate the syscall number, in the context of the native architecture, to
+ * the provided architecture.  Returns zero on success, negative values on
  * failure.
  *
  */

--- a/src/db.c
+++ b/src/db.c
@@ -1058,7 +1058,7 @@ int db_col_reset(struct db_filter_col *col, uint32_t def_action)
 		free(col->filters);
 	col->filters = NULL;
 
-	/* set the endianess to undefined */
+	/* set the endianness to undefined */
 	col->endian = 0;
 
 	/* set the default attribute values */
@@ -1222,7 +1222,7 @@ int db_col_merge(struct db_filter_col *col_dst, struct db_filter_col *col_src)
 	unsigned int iter_a, iter_b;
 	struct db_filter **dbs;
 
-	/* verify that the endianess is a match */
+	/* verify that the endianness is a match */
 	if (col_dst->endian != col_src->endian)
 		return -EDOM;
 

--- a/src/gen_bpf.c
+++ b/src/gen_bpf.c
@@ -205,11 +205,11 @@ static struct bpf_blk *_hsh_remove(struct bpf_state *state, uint64_t h_val);
 static struct bpf_blk *_hsh_find(const struct bpf_state *state, uint64_t h_val);
 
 /**
- * Convert a 16-bit host integer into the target's endianess
+ * Convert a 16-bit host integer into the target's endianness
  * @param arch the architecture definition
  * @param val the 16-bit integer
  *
- * Convert the endianess of the supplied value and return it to the caller.
+ * Convert the endianness of the supplied value and return it to the caller.
  *
  */
 static uint16_t _htot16(const struct arch_def *arch, uint16_t val)
@@ -221,11 +221,11 @@ static uint16_t _htot16(const struct arch_def *arch, uint16_t val)
 }
 
 /**
- * Convert a 32-bit host integer into the target's endianess
+ * Convert a 32-bit host integer into the target's endianness
  * @param arch the architecture definition
  * @param val the 32-bit integer
  *
- * Convert the endianess of the supplied value and return it to the caller.
+ * Convert the endianness of the supplied value and return it to the caller.
  *
  */
 static uint32_t _htot32(const struct arch_def *arch, uint32_t val)
@@ -1303,7 +1303,7 @@ static inline bool _skip_syscall(struct bpf_state *state,
 	if (!syscall->valid)
 		return true;
 
-	/* psuedo-syscalls should not be added to the filter unless explicity
+	/* psuedo-syscalls should not be added to the filter unless explicitly
 	 * requested via SCMP_FLTATR_API_TSKIP
 	 */
 	if (((int)syscall->num < 0) &&
@@ -1662,7 +1662,7 @@ out:
  * @param db_secondary the secondary DB
  *
  * Generate the BPF instruction block for the given filter DB(s)/architecture(s)
- * and return a pointer to the block on succes, NULL on failure.  The resulting
+ * and return a pointer to the block on success, NULL on failure.  The resulting
  * block assumes that the architecture token has already been loaded into the
  * BPF accumulator.
  *

--- a/src/system.h
+++ b/src/system.h
@@ -91,7 +91,7 @@ struct seccomp_data {
 /* rename some of the socket filter types to make more sense */
 typedef struct sock_filter bpf_instr_raw;
 
-/* no new privs defintions */
+/* no new privs definitions */
 #ifndef PR_SET_NO_NEW_PRIVS
 #define PR_SET_NO_NEW_PRIVS		38
 #endif

--- a/tools/check-syntax
+++ b/tools/check-syntax
@@ -28,6 +28,8 @@ CHK_C_LIST="include/seccomp.h.in \
 	    tools/*.c tools/*.h"
 CHK_C_EXCLUDE="src/syscalls.perf.c"
 
+CHK_SPELL_EXCLUDE_WORDS=""
+
 ####
 # functions
 
@@ -60,13 +62,23 @@ EOF
 }
 
 #
+# Spellcheck source code
+#
+function tool_spell_check() {
+	local tfile
+
+	tfile=$(mktemp -t check-syntax-XXXXXX)
+	cat - > $tfile
+	codespell -q 16 -d -w -L "$CHK_SPELL_EXCLUDE_WORDS" $tfile
+	cat $tfile
+	rm -f $tfile
+}
+
+#
 # Generate a properly formatted C source/header file
 #
-# Arguments:
-#     1    Source file
-#
 function tool_c_style() {
-	astyle --options=none --lineend=linux --mode=c \
+	cat - | astyle --options=none --lineend=linux --mode=c \
 		--style=linux \
 		--indent=force-tab=8 \
 		--indent-preprocessor \
@@ -77,7 +89,17 @@ function tool_c_style() {
 		--align-pointer=name \
 		--align-reference=name \
 		--max-code-length=80 \
-		--break-after-logical < "$1"
+		--break-after-logical
+}
+
+#
+# Generate a properly formatted and spellchecked C source/header file
+#
+# Arguments:
+#     1    Source file
+#
+function tool_c_ideal() {
+	cat "$1" | tool_spell_check | tool_c_style
 }
 
 #
@@ -89,7 +111,7 @@ function tool_c_style() {
 function tool_c_style_check() {
 	[[ -z "$1" || ! -r "$1" ]] && return
 
-	tool_c_style "$1" | diff -pu --label="$1.orig" "$1" --label="$1" -
+	tool_c_ideal "$1" | diff -pu --label="$1.orig" "$1" --label="$1" -
 }
 
 #
@@ -102,7 +124,7 @@ function tool_c_style_fix() {
 	[[ -z "$1" || ! -r "$1" ]] && return
 
 	tmp="$(mktemp --tmpdir=$(dirname "$1"))"
-	tool_c_style "$1" > "$tmp"
+	tool_c_ideal "$1" > "$tmp"
 	mv "$tmp" "$1"
 }
 
@@ -132,6 +154,7 @@ function fix_c() {
 # main
 
 verify_deps astyle
+verify_deps codespell
 
 opt_fix=0
 

--- a/tools/scmp_bpf_sim.c
+++ b/tools/scmp_bpf_sim.c
@@ -328,7 +328,7 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	/* adjust the endianess of sys_data to match the target */
+	/* adjust the endianness of sys_data to match the target */
 	sys_data.nr = htot32(arch, sys_data.nr);
 	sys_data.arch = htot32(arch, arch);
 	sys_data.instruction_pointer = htot64(arch,

--- a/tools/util.c
+++ b/tools/util.c
@@ -88,11 +88,11 @@
 uint32_t arch = ARCH_NATIVE;
 
 /**
- * Convert a 16-bit target integer into the host's endianess
+ * Convert a 16-bit target integer into the host's endianness
  * @param arch_token the architecture token
  * @param val the 16-bit integer
  *
- * Convert the endianess of the supplied value and return it to the caller.
+ * Convert the endianness of the supplied value and return it to the caller.
  *
  */
 uint16_t ttoh16(uint32_t arch_token, uint16_t val)
@@ -104,11 +104,11 @@ uint16_t ttoh16(uint32_t arch_token, uint16_t val)
 }
 
 /**
- * Convert a 32-bit target integer into the host's endianess
+ * Convert a 32-bit target integer into the host's endianness
  * @param arch_token the architecture token
  * @param val the 32-bit integer
  *
- * Convert the endianess of the supplied value and return it to the caller.
+ * Convert the endianness of the supplied value and return it to the caller.
  *
  */
 uint32_t ttoh32(uint32_t arch_token, uint32_t val)
@@ -120,11 +120,11 @@ uint32_t ttoh32(uint32_t arch_token, uint32_t val)
 }
 
 /**
- * Convert a 32-bit host integer into the target's endianess
+ * Convert a 32-bit host integer into the target's endianness
  * @param arch_token the architecture token
  * @param val the 32-bit integer
  *
- * Convert the endianess of the supplied value and return it to the caller.
+ * Convert the endianness of the supplied value and return it to the caller.
  *
  */
 uint32_t htot32(uint32_t arch_token, uint32_t val)
@@ -136,11 +136,11 @@ uint32_t htot32(uint32_t arch_token, uint32_t val)
 }
 
 /**
- * Convert a 64-bit host integer into the target's endianess
+ * Convert a 64-bit host integer into the target's endianness
  * @param arch_token the architecture token
  * @param val the 64-bit integer
  *
- * Convert the endianess of the supplied value and return it to the caller.
+ * Convert the endianness of the supplied value and return it to the caller.
  *
  */
 uint64_t htot64(uint32_t arch_token, uint64_t val)


### PR DESCRIPTION
This is a low priority, and far from perfect item, but I think it would be nice to have to help improve code quality/readability.  The one draback is that it adds another dependency to the "./tools/check-syntax" script, but the `codespell` tool seems to be readily available in most distros I believe.