### PR TITLE
BUG: update CONTRIBUTING with some community guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-How to Submit Patches to the libseccomp Project
+How to Contribute to the libseccomp Project
 ===============================================================================
 https://github.com/seccomp/libseccomp
 
@@ -7,6 +7,20 @@ libseccomp project.  It is not perfect, and there will always be exceptions
 to the rules described here, but by following the instructions below you
 should have a much easier time getting your work merged with the upstream
 project.
+
+## Interacting with the Community
+
+> "Be excellent to each other." - *Bill S. Preston, Esq.*
+
+The libseccomp project aims to be a welcoming place and we ask that anyone who
+interacts with the project, and the greater community, treat each other with
+dignity and respect.  Individuals who do not behave in such a manner will be
+warned and asked to adjust their behavior; in extreme cases the individual
+may be blocked from the project.
+
+Examples of inappropriate behavior includes: profane, abusive, or prejudicial
+language directed at another person, vandalism (e.g. GitHub issue/PR "litter"),
+or spam.
 
 ## Test Your Code Using Existing Tests
 

--- a/doc/admin/MAINTAINER_PROCESS.md
+++ b/doc/admin/MAINTAINER_PROCESS.md
@@ -89,6 +89,24 @@ there is no requirement to do so.
 Despite the term "moderator" the list is currently unmoderated and should
 remain the way.
 
+### Handling Inappropriate Community Behavior
+
+The libseccomp project community is relatively small, and almost always
+respectful and considerate.  However, there have been some limited cases of
+inappropriate behavior and it is the responsibility of the maintainers to deal
+with it accordingly.
+
+As mentioned above, the maintainers are encouraged to communicate with each
+other, and this communication is very important in this case.  When
+inappropriate behavior is identified in the project (e.g. mailing list, GitHub,
+etc.) the maintainers should talk with each other as well as the responsible
+individual to try and correct the behavior.  If the individual continues to act
+inappropriately the maintainers can block the individual from the project using
+whatever means are available.  This should only be done as a last resort, and
+with the agreement of all the maintainers.  In cases where a quick response is
+necessary, a maintainer can unilaterally block an individual, but the block
+should be reviewed by all the other maintainers soon afterwards.
+
 ### New Project Releases
 
 The libseccomp release process is documented in the RELEASE_PROCESS.md


### PR DESCRIPTION
An initial take of establishing some basic community guidelines and some maintainer rules for what to do when things go wrong.  This generally isn't a problem for libseccomp so I'm trying to tread lightly here, but recent events had made it clear we need to be better prepared to handle issues relating to problematic individuals.

@drakenclimber please review and offer any comments, suggestions you may have.