### PR TITLE
doc: Fix typo in seccomp_api_get.3

### DIFF
--- a/doc/man/man3/seccomp_api_get.3
+++ b/doc/man/man3/seccomp_api_get.3
@@ -1,4 +1,4 @@
-.TH "seccomp_api_get" 3 "13 June 2020" "paul@paul-moore.com" "libseccomp Documentation"
+.TH "seccomp_api_get" 3 "6 November 2020" "paul@paul-moore.com" "libseccomp Documentation"
 .\" //////////////////////////////////////////////////////////////////////////
 .SH NAME
 .\" //////////////////////////////////////////////////////////////////////////
@@ -58,7 +58,7 @@ The SCMP_FLTATR_CTL_SSB filter attribute is supported.
 .B 5
 The SCMP_ACT_NOTIFY action and the notify APIs are supported.
 .TP
-.B 5
+.B 6
 The simultaneous use of SCMP_FLTATR_CTL_TSYNC and the notify APIs are supported.
 .\" //////////////////////////////////////////////////////////////////////////
 .SH RETURN VALUE


### PR DESCRIPTION
Commit 6b286c2e8e43de76746346b8eab855311915f5aa ("api: add API level 6")
introduced the API level 6 but had a typo and used 5 in the manpage.

This commit just fixes the typo using API level 6 in the manpage.

Signed-off-by: Rodrigo Campos <rodrigo@kinvolk.io>