### PR TITLE
BUG: use old SECCOMP_IOCTL_NOTIF_ID_VALID number if necessary

### DIFF
--- a/src/system.h
+++ b/src/system.h
@@ -179,8 +179,10 @@ struct seccomp_notif_resp {
 #define SECCOMP_IOCTL_NOTIF_RECV        SECCOMP_IOWR(0, struct seccomp_notif)
 #define SECCOMP_IOCTL_NOTIF_SEND        SECCOMP_IOWR(1, \
 						     struct seccomp_notif_resp)
-#define SECCOMP_IOCTL_NOTIF_ID_VALID    SECCOMP_IOR(2, __u64)
+#define SECCOMP_IOCTL_NOTIF_ID_VALID    SECCOMP_IOW(2, __u64)
 #endif /* SECCOMP_RET_USER_NOTIF */
+/* non-public ioctl number for backwards compat (see system.c) */
+#define SECCOMP_IOCTL_NOTIF_ID_VALID_WRONG_DIR SECCOMP_IOR(2, __u64)
 
 void sys_reset_state(void);
 


### PR DESCRIPTION
[Kernel commit 47e33c05f9f07cac3de833e531bcac9ae052c7ca](https://git.kernel.org/torvalds/c/47e33c05f9f07cac3de833e531bcac9ae052c7ca) changed the
public definition of SECCOMP_IOCTL_NOTIF_ID_VALID for correctness sake
because it had the wrong direction (no current functional change). If
libseccomp is built against kernel headers after this commit but is run
on a kernel that was built prior to this commit, then the ioctl will
always return EINVAL and thus seccomp_notify_id_valid will incorrectly
return -ENOENT.

Copy the (now non-public) definition of the old ioctl number and try it
if the ioctl with the number from the kernel headers fails with -1
EINVAL.

Signed-off-by: Max Rees <maxcrees@me.com>

----

**Note**: should I also update the value of `SECCOMP_IOCTL_NOTIF_ID_VALID` in the `#ifndef SECCOMP_RET_USER_NOTIF` in `src/system.h` while I'm at it?