### PR TITLE
RFE: improve test performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ install:
 script:
   - ./configure --enable-python
   - make check-build
-  - LIBSECCOMP_TSTCFG_STRESSCNT=5 make check
+  - make check
   - LIBSECCOMP_TSTCFG_TYPE=live LIBSECCOMP_TSTCFG_MODE_LIST=c make -C tests check
   - |
     if [ $TRAVIS_CPU_ARCH == "amd64" -o -x scan-build ]; then

--- a/tests/01-sim-allow.tests
+++ b/tests/01-sim-allow.tests
@@ -13,7 +13,7 @@ test type: bpf-sim
 test type: bpf-sim-fuzz
 
 # Testname	StressCount
-01-sim-allow	50
+01-sim-allow	5
 
 test type: bpf-valgrind
 

--- a/tests/02-sim-basic.tests
+++ b/tests/02-sim-basic.tests
@@ -22,7 +22,7 @@ test type: bpf-sim
 test type: bpf-sim-fuzz
 
 # Testname	StressCount
-02-sim-basic	50
+02-sim-basic	5
 
 test type: bpf-valgrind
 

--- a/tests/03-sim-basic_chains.tests
+++ b/tests/03-sim-basic_chains.tests
@@ -24,7 +24,7 @@ test type: bpf-sim
 test type: bpf-sim-fuzz
 
 # Testname		StressCount
-03-sim-basic_chains	50
+03-sim-basic_chains	5
 
 test type: bpf-valgrind
 

--- a/tests/04-sim-multilevel_chains.tests
+++ b/tests/04-sim-multilevel_chains.tests
@@ -36,7 +36,7 @@ test type: bpf-sim
 test type: bpf-sim-fuzz
 
 # Testname			StressCount
-04-sim-multilevel_chains	50
+04-sim-multilevel_chains	5
 
 test type: bpf-valgrind
 

--- a/tests/05-sim-long_jumps.tests
+++ b/tests/05-sim-long_jumps.tests
@@ -29,7 +29,7 @@ test type: bpf-sim
 test type: bpf-sim-fuzz
 
 # Testname		StressCount
-05-sim-long_jumps	50
+05-sim-long_jumps	5
 
 test type: bpf-valgrind
 

--- a/tests/06-sim-actions.tests
+++ b/tests/06-sim-actions.tests
@@ -26,7 +26,7 @@ test type: bpf-sim
 test type: bpf-sim-fuzz
 
 # Testname	StressCount
-06-sim-actions	50
+06-sim-actions	5
 
 test type: bpf-valgrind
 

--- a/tests/07-sim-db_bug_looping.tests
+++ b/tests/07-sim-db_bug_looping.tests
@@ -15,7 +15,7 @@ test type: bpf-sim
 test type: bpf-sim-fuzz
 
 # Testname		StressCount
-07-sim-db_bug_looping	50
+07-sim-db_bug_looping	5
 
 test type: bpf-valgrind
 

--- a/tests/08-sim-subtree_checks.tests
+++ b/tests/08-sim-subtree_checks.tests
@@ -38,7 +38,7 @@ test type: bpf-sim
 test type: bpf-sim-fuzz
 
 # Testname		StressCount
-08-sim-subtree_checks	50
+08-sim-subtree_checks	5
 
 
 test type: bpf-valgrind

--- a/tests/09-sim-syscall_priority_pre.tests
+++ b/tests/09-sim-syscall_priority_pre.tests
@@ -18,7 +18,7 @@ test type: bpf-sim
 test type: bpf-sim-fuzz
 
 # Testname			StressCount
-09-sim-syscall_priority_pre	50
+09-sim-syscall_priority_pre	5
 
 test type: bpf-valgrind
 

--- a/tests/10-sim-syscall_priority_post.tests
+++ b/tests/10-sim-syscall_priority_post.tests
@@ -18,7 +18,7 @@ test type: bpf-sim
 test type: bpf-sim-fuzz
 
 # Testname			StressCount
-10-sim-syscall_priority_post	50
+10-sim-syscall_priority_post	5
 
 test type: bpf-valgrind
 

--- a/tests/12-sim-basic_masked_ops.tests
+++ b/tests/12-sim-basic_masked_ops.tests
@@ -40,7 +40,7 @@ test type: bpf-sim
 test type: bpf-sim-fuzz
 
 # Testname		StressCount
-12-sim-basic_masked_ops	50
+12-sim-basic_masked_ops	5
 
 test type: bpf-valgrind
 

--- a/tests/14-sim-reset.tests
+++ b/tests/14-sim-reset.tests
@@ -21,7 +21,7 @@ test type: bpf-sim
 test type: bpf-sim-fuzz
 
 # Testname	StressCount
-14-sim-reset	50
+14-sim-reset	5
 
 test type: bpf-valgrind
 

--- a/tests/18-sim-basic_allowlist.tests
+++ b/tests/18-sim-basic_allowlist.tests
@@ -24,7 +24,7 @@ test type: bpf-sim
 test type: bpf-sim-fuzz
 
 # Testname		StressCount
-18-sim-basic_allowlist	50
+18-sim-basic_allowlist	5
 
 test type: bpf-valgrind
 

--- a/tests/22-sim-basic_chains_array.tests
+++ b/tests/22-sim-basic_chains_array.tests
@@ -23,7 +23,7 @@ test type: bpf-sim
 test type: bpf-sim-fuzz
 
 # Testname			StressCount
-22-sim-basic_chains_array	50
+22-sim-basic_chains_array	5
 
 test type: bpf-valgrind
 

--- a/tests/25-sim-multilevel_chains_adv.tests
+++ b/tests/25-sim-multilevel_chains_adv.tests
@@ -22,7 +22,7 @@ test type: bpf-sim
 test type: bpf-sim-fuzz
 
 # Testname			StressCount
-25-sim-multilevel_chains_adv	50
+25-sim-multilevel_chains_adv	5
 
 test type: bpf-valgrind
 

--- a/tests/27-sim-bpf_blk_state.tests
+++ b/tests/27-sim-bpf_blk_state.tests
@@ -16,7 +16,7 @@ test type: bpf-sim
 test type: bpf-sim-fuzz
 
 # Testname		StressCount
-27-sim-bpf_blk_state	50
+27-sim-bpf_blk_state	5
 
 test type: bpf-valgrind
 

--- a/tests/34-sim-basic_denylist.tests
+++ b/tests/34-sim-basic_denylist.tests
@@ -24,7 +24,7 @@ test type: bpf-sim
 test type: bpf-sim-fuzz
 
 # Testname		StressCount
-34-sim-basic_denylist	50
+34-sim-basic_denylist	5
 
 test type: bpf-valgrind
 

--- a/tests/40-sim-log.tests
+++ b/tests/40-sim-log.tests
@@ -13,7 +13,7 @@ test type: bpf-sim
 test type: bpf-sim-fuzz
 
 # Testname	StressCount
-40-sim-log	50
+40-sim-log	5
 
 test type: bpf-valgrind
 

--- a/tests/42-sim-adv_chains.tests
+++ b/tests/42-sim-adv_chains.tests
@@ -45,8 +45,8 @@ test type: bpf-sim
 
 test type: bpf-sim-fuzz
 
-# Testname			StressCount
-42-sim-adv_chains	50
+# Testname		StressCount
+42-sim-adv_chains	5
 
 test type: bpf-valgrind
 

--- a/tests/48-sim-32b_args.tests
+++ b/tests/48-sim-32b_args.tests
@@ -30,7 +30,7 @@ test type: bpf-sim
 test type: bpf-sim-fuzz
 
 # Testname		StressCount
-48-sim-32b_args		50
+48-sim-32b_args		5
 
 test type: bpf-valgrind
 

--- a/tests/regression
+++ b/tests/regression
@@ -89,12 +89,13 @@ function verify_deps() {
 #
 function usage() {
 cat << EOF
-usage: regression [-h] [-v] [-m MODE] [-a] [-b BATCH_NAME] [-l <LOG>]
-                  [-s SINGLE_TEST] [-t <TEMP_DIR>] [-T <TEST_TYPE>]
+usage: regression [-h] [-v] [-j JOBS] [-m MODE] [-a] [-b BATCH_NAME]
+                  [-l <LOG>] [-s SINGLE_TEST] [-t <TEMP_DIR>] [-T <TEST_TYPE>]
 
 libseccomp regression test automation script
 optional arguments:
   -h             show this help message and exit
+  -j JOBS        run up to JOBS test jobs in parallel
   -m MODE        specified the test mode [c (default), python]
                   can also be set via LIBSECCOMP_TSTCFG_MODE_LIST env variable
   -a             specifies all tests are to be run
@@ -881,12 +882,114 @@ function run_test() {
 }
 
 #
+# Run the requested test batch
+#
+# Arguments:
+#     1    Batch name
+#
+function run_test_batch() {
+	local testnum=1
+	local batch_name=$1
+
+	# open temporary file
+	if [[ -n $tmpdir ]]; then
+		tmpfile=$(mktemp -t regression_XXXXXX --tmpdir=$tmpdir)
+	else
+		tmpfile=$(mktemp -t regression_XXXXXX)
+	fi
+
+	# reset the stats
+	stats_all=0
+	stats_skipped=0
+	stats_success=0
+	stats_failure=0
+	stats_error=0
+
+	# print a test batch header
+	echo " batch name: $batch_name" >&$logfd
+
+	# loop through each line and run the requested tests
+	while read line; do
+		# strip whitespace, comments, and blank lines
+		line=$(echo "$line" | \
+			sed -e 's/^[\t ]*//;s/[\t ]*$//;' | \
+			sed -e '/^[#].*$/d;/^$/d')
+		if [[ -z $line ]]; then
+			continue
+		fi
+
+		if [[ $line =~ ^"test type": ]]; then
+			test_type=$(echo "$line" | \
+					sed -e 's/^test type: //;')
+			# print a test mode and type header
+			echo " test mode:  $mode" >&$logfd
+			echo " test type:  $test_type" >&$logfd
+			continue
+		fi
+
+		if [[ ${single_list[@]} ]]; then
+			for i in ${single_list[@]}; do
+				if [ $i -eq $testnum ]; then
+					# we're running a single test
+					run_test "$batch_name" \
+							$testnum "$line" \
+							"$test_type"
+				fi
+			done
+		else
+			# we're running a test from a batch
+			run_test "$batch_name" \
+					$testnum "$line" "$test_type"
+		fi
+		testnum=$(($testnum+1))
+	done < "$file"
+
+
+	# dump our stats
+	local stats=$batch_name.$mode.stats
+	> $stats
+	echo -n "$stats_all $stats_skipped $stats_success " >> $stats
+	echo -n "$stats_failure $stats_error " >> $stats
+	echo "" >> $stats
+
+	# cleanup the temporary file we created
+	rm -f $tmpfile
+}
+
+#
+# Run the requested test batch
+#
+# Arguments:
+#     1    Log file
+#     2    PID to watch
+#
+function tail_log() {
+	local log=$1
+	local pid=$2
+
+	# dump the output
+	tail -n +0 --pid=$pid -f $log
+
+	# accumulate the stats
+	local stats=$(echo $log | sed 's/\.log$/.stats/')
+	stats_all=$(( $stats_all + $(awk '{ print $1 }' $stats) ))
+	stats_skipped=$(( $stats_skipped + $(awk '{ print $2 }' $stats) ))
+	stats_success=$(( $stats_success + $(awk '{ print $3 }' $stats) ))
+	stats_failure=$(( $stats_failure + $(awk '{ print $4 }' $stats) ))
+	stats_error=$(( $stats_error + $(awk '{ print $5 }' $stats) ))
+}
+
+#
 # Run the requested tests
 #
 function run_tests() {
+	local job_cnt=0
+	local tail_cnt=0
+	local -a job_pids
+	local -a job_logs
+
 	# loop through all test files
 	for file in $basedir/*.tests; do
-		local testnum=1
 		local batch_requested=false
 		local batch_name=""
 
@@ -906,44 +1009,22 @@ function run_tests() {
 			fi
 		fi
 
-		# print a test batch header
-		echo " batch name: $batch_name" >&$logfd
+		# run the test batch
+		run_test_batch $batch_name >& $batch_name.$mode.log &
+		job_pids[job_cnt]=$!
+		job_logs[job_cnt]=$batch_name.$mode.log
+		job_cnt=$(( $job_cnt + 1 ))
 
-		# loop through each line and run the requested tests
-		while read line; do
-			# strip whitespace, comments, and blank lines
-			line=$(echo "$line" | \
-			       sed -e 's/^[\t ]*//;s/[\t ]*$//;' | \
-			       sed -e '/^[#].*$/d;/^$/d')
-			if [[ -z $line ]]; then
-				continue
-			fi
+		# output the next log if the job queue is full
+		if [[ $(jobs | wc -l) -ge $jobs ]]; then
+			tail_log ${job_logs[$tail_cnt]} ${job_pids[$tail_cnt]}
+			tail_cnt=$(( $tail_cnt + 1 ))
+		fi
+	done
 
-			if [[ $line =~ ^"test type": ]]; then
-				test_type=$(echo "$line" | \
-					    sed -e 's/^test type: //;')
-				# print a test mode and type header
-				echo " test mode:  $mode" >&$logfd
-				echo " test type:  $test_type" >&$logfd
-				continue
-			fi
-
-			if [[ ${single_list[@]} ]]; then
-				for i in ${single_list[@]}; do
-					if [ $i -eq $testnum ]; then
-						# we're running a single test
-						run_test "$batch_name" \
-							 $testnum "$line" \
-							 "$test_type"
-					fi
-				done
-			else
-				# we're running a test from a batch
-				run_test "$batch_name" \
-					 $testnum "$line" "$test_type"
-			fi
-			testnum=$(($testnum+1))
-		done < "$file"
+	# output any leftovers
+	for i in $(seq $tail_cnt $(( $job_cnt - 1 ))); do
+		tail_log ${job_logs[$i]} ${job_pids[$i]}
 	done
 }
 
@@ -970,6 +1051,7 @@ tmpfile=""
 tmpdir=""
 type=
 verbose=
+jobs=1
 stats_all=0
 stats_skipped=0
 stats_success=0
@@ -983,7 +1065,7 @@ basedir=$(dirname $0)
 pid=$$
 
 # parse the command line
-while getopts "ab:gl:m:s:t:T:vh" opt; do
+while getopts "ab:gj:l:m:s:t:T:vh" opt; do
 	case $opt in
 	a)
 		runall=1
@@ -991,6 +1073,13 @@ while getopts "ab:gl:m:s:t:T:vh" opt; do
 	b)
 		batch_list[batch_count]="$OPTARG"
 		batch_count=$(($batch_count+1))
+		;;
+	j)
+		if [[ $OPTARG -lt 1 ]]; then
+			jobs=$(cat /proc/cpuinfo | grep "^processor" | wc -l)
+		else
+			jobs=$OPTARG
+		fi
 		;;
 	l)
 		logfile="$OPTARG"
@@ -1062,17 +1151,13 @@ fi
 
 # open log file for append (default to stdout)
 if [[ -n $logfile ]]; then
+	# force single threaded to preserve the output
+	jobs=1
+
 	logfd=3
 	exec 3>>"$logfile"
 else
 	logfd=1
-fi
-
-# open temporary file
-if [[ -n $tmpdir ]]; then
-	tmpfile=$(mktemp -t regression_XXXXXX --tmpdir=$tmpdir)
-else
-	tmpfile=$(mktemp -t regression_XXXXXX)
 fi
 
 # determine the current system's architecture
@@ -1093,7 +1178,6 @@ echo " tests errored: $stats_error" >&$logfd
 echo "============================================================" >&$logfd
 
 # cleanup and exit
-rm -f $tmpfile
 rc=0
 [[ $stats_failure -gt 0 ]] && rc=$(($rc + 2))
 [[ $stats_error -gt 0 ]] && rc=$(($rc + 4))

--- a/tests/regression
+++ b/tests/regression
@@ -96,6 +96,7 @@ libseccomp regression test automation script
 optional arguments:
   -h             show this help message and exit
   -j JOBS        run up to JOBS test jobs in parallel
+                  can also be set via LIBSECCOMP_TSTCFG_JOBS env variable
   -m MODE        specified the test mode [c (default), python]
                   can also be set via LIBSECCOMP_TSTCFG_MODE_LIST env variable
   -a             specifies all tests are to be run
@@ -1075,11 +1076,7 @@ while getopts "ab:gj:l:m:s:t:T:vh" opt; do
 		batch_count=$(($batch_count+1))
 		;;
 	j)
-		if [[ $OPTARG -lt 1 ]]; then
-			jobs=$(cat /proc/cpuinfo | grep "^processor" | wc -l)
-		else
-			jobs=$OPTARG
-		fi
+		jobs=$OPTARG
 		;;
 	l)
 		logfile="$OPTARG"
@@ -1120,6 +1117,12 @@ done
 
 # use mode list from environment if provided
 [[ -z $mode_list && -n $LIBSECCOMP_TSTCFG_MODE_LIST ]] && mode_list=$LIBSECCOMP_TSTCFG_MODE_LIST
+
+# use job count from environment if provided and do some sanity checking
+[[ -n $LIBSECCOMP_TSTCFG_JOBS ]] && jobs=$LIBSECCOMP_TSTCFG_JOBS
+if [[ $jobs -lt 1 ]]; then
+	jobs=$(cat /proc/cpuinfo | grep "^processor" | wc -l)
+fi
 
 # determine the mode test automatically
 if [[ -z $mode_list ]]; then


### PR DESCRIPTION
This PR has two patches intended to speed up the automated regression tests. The first patch adds support for running the tests in parallel, similar to `make -jX`, and the second patch limits the test fuzzing to five iterations for each test, just as we do for the Travis CI runs today.

The individual patch descriptions have more information on the changes and the performance increases for each, but cumulatively this PR drops the test run time from over 14 minutes to just over 3.5 minutes on my eight core laptop.