### PR TITLE
BUG: fix uninitialized value usage in gen_bpf.c

### DIFF
--- a/src/helper.c
+++ b/src/helper.c
@@ -34,18 +34,11 @@
  */
 void *zmalloc(size_t size)
 {
-	void *ptr;
-
 	/* NOTE: unlike malloc() zero size allocations always return NULL */
 	if (size == 0)
 		return NULL;
 
-	ptr = malloc(size);
-	if (!ptr)
-		return NULL;
-	memset(ptr, 0, size);
-
-	return ptr;
+	return calloc(1, size);
 }
 
 /**

--- a/src/helper.c
+++ b/src/helper.c
@@ -47,3 +47,28 @@ void *zmalloc(size_t size)
 
 	return ptr;
 }
+
+/**
+ * Change the size of an allocated buffer
+ * @param ptr pointer to the allocated buffer.  If NULL it is equivalent to zmalloc.
+ * @param old_size the current size of the allocated buffer
+ * @param size the new size of the buffer
+ *
+ * This function changes the size of an allocated memory buffer and return a pointer
+ * to the buffer on success, the new buffer portion is initialized to zero.  NULL is
+ * returned on failure.  The returned buffer could be different than the specified
+ * ptr param.
+ *
+ */
+void *zrealloc(void *ptr, size_t old_size, size_t size)
+{
+	/* NOTE: unlike malloc() zero size allocations always return NULL */
+	if (size == 0)
+		return NULL;
+
+	ptr = realloc(ptr, size);
+	if (!ptr)
+		return NULL;
+	memset(ptr + old_size, 0, size - old_size);
+	return ptr;
+}

--- a/src/helper.h
+++ b/src/helper.h
@@ -23,5 +23,6 @@
 #define _FILTER_HELPER_H
 
 void *zmalloc(size_t size);
+void *zrealloc(void *ptr, size_t old_size, size_t size);
 
 #endif


### PR DESCRIPTION
it was reported by clang with the option -fsanitize=memory:

Uninitialized bytes in MemcmpInterceptorCommon at offset 0 inside [0x7070000002a0, 56)
==3791089==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x482a2c in memcmp (fuzzer+0x482a2c)
    #1 0x7fed2f120ebb in _hsh_add src/libseccomp/src/gen_bpf.c:598:9
    #2 0x7fed2f121715 in _gen_bpf_action_hsh src/libseccomp/src/gen_bpf.c:796:6
    #3 0x7fed2f121a53 in _gen_bpf_node src/libseccomp/src/gen_bpf.c:831:11
    #4 0x7fed2f121a53 in _gen_bpf_chain.isra.0 src/libseccomp/src/gen_bpf.c:1072:13
    #5 0x7fed2f121f16 in _gen_bpf_chain_lvl_res src/libseccomp/src/gen_bpf.c:977:12
    #6 0x7fed2f121c74 in _gen_bpf_chain.isra.0 src/libseccomp/src/gen_bpf.c:1124:12
    #7 0x7fed2f12253c in _gen_bpf_syscall src/libseccomp/src/gen_bpf.c:1520:10
    #8 0x7fed2f12253c in _gen_bpf_syscalls src/libseccomp/src/gen_bpf.c:1615:18
    #9 0x7fed2f12253c in _gen_bpf_arch src/libseccomp/src/gen_bpf.c:1683:7
    #10 0x7fed2f12253c in _gen_bpf_build_bpf src/libseccomp/src/gen_bpf.c:2056:11
    #11 0x7fed2f12253c in gen_bpf_generate src/libseccomp/src/gen_bpf.c:2321:7
    #12 0x7fed2f11f41c in seccomp_export_bpf src/libseccomp/src/api.c:724:7

  Uninitialized value was created by a heap allocation
    #0 0x4547ef in realloc (fuzzer+0x4547ef)
    #1 0x7fed2f121244 in _blk_resize src/libseccomp/src/gen_bpf.c:362:8
    #2 0x7fed2f121244 in _blk_append src/libseccomp/src/gen_bpf.c:394:6

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>