### PR TITLE
doc: Add BUGS section to seccomp_rule_add.3

### DIFF
--- a/doc/man/man3/seccomp_rule_add.3
+++ b/doc/man/man3/seccomp_rule_add.3
@@ -425,6 +425,24 @@ repository, can be found at https://github.com/seccomp/libseccomp.  This tool,
 as well as the libseccomp library, is currently under development, please
 report any bugs at the project site or directly to the author.
 .\" //////////////////////////////////////////////////////////////////////////
+.SH BUGS
+.\" //////////////////////////////////////////////////////////////////////////
+.P
+The runtime behavior of seccomp filters is dependent upon the kernel
+version, the processor architecture, and other libraries including libc.
+This could affect the return code of a seccomp filter.
+
+.TP
+.B *
+PowerPC glibc will not return a negative number when the
+.B getpid()
+syscall is invoked.  If a seccomp filter has been created where
+.B getpid()
+will return a negative number from the kernel, then PowerPC glibc will
+return the absolute value of the errno.  In this case, it is very difficult
+for an application to distinguish between the errno and a valid pid.
+
+.\" //////////////////////////////////////////////////////////////////////////
 .SH AUTHOR
 .\" //////////////////////////////////////////////////////////////////////////
 Paul Moore <paul@paul-moore.com>


### PR DESCRIPTION
Add BUGS section to seccomp_rule_add.3 and add a warning about
adding a seccomp filter to syscalls that are always expected to
succeed.

PowerPC's glibc behaves differently from other architectures and
will not return a negative number for the getpid() syscall.

Fixes: https://github.com/seccomp/libseccomp/issues/313
Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>