### PR TITLE
BUG: Python test #24 failure due to munmap()

### DIFF
--- a/tests/24-live-arg_allow.py
+++ b/tests/24-live-arg_allow.py
@@ -41,6 +41,7 @@ def test():
     # NOTE: additional syscalls required for python
     f.add_rule(ALLOW, "write", Arg(0, EQ, fd))
     f.add_rule(ALLOW, "close")
+    f.add_rule(ALLOW, "munmap")
     f.add_rule(ALLOW, "rt_sigaction")
     f.add_rule(ALLOW, "rt_sigreturn")
     f.add_rule(ALLOW, "sigaltstack")


### PR DESCRIPTION
The python live test, 24-live-arg_allow.py, started failing on
Fedora 34 with kernel 5.13.9-200.fc34.x86_64.  To fix this, allow
the munmap() syscall in the test's seccomp filter.

Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>