### PR TITLE
BUG: fix warning in 05-sim-long_jumps.c

### DIFF
--- a/tests/05-sim-long_jumps.c
+++ b/tests/05-sim-long_jumps.c
@@ -23,6 +23,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <limits.h>
+#include <stdlib.h>
 
 #include <seccomp.h>
 


### PR DESCRIPTION
I just did a build on a more current linux box and spotted this warning.  Easy fix:


Commit 3c2da115b5b35 "tests: improve 05-sim-long_jumps to work better
across arch/ABIs" introduced the following warning.  Let's fix it.

	05-sim-long_jumps.c: In function ‘main’:
	05-sim-long_jumps.c:68:25: warning: implicit declaration of function ‘free’ [-Wimplicit-function-declaration]
	   68 |                         free(syscall);

Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>