### PR TITLE
BUG: add tests/*.{log,stats} to .gitignore

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,6 +1,8 @@
 *.bpf
 *.bpfd
 *.pfc
+*.log
+*.stats
 __pycache__/
 miniseq
 util.pyc


### PR DESCRIPTION
Untrack `*.log` and `*.stats` files such as `01-sim-allow.c.{log,stats}`
intentionally because these files are generated in the `tests` directory
by running tests.

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>