### PR TITLE
RFE: enable CodeQL code scanning and analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,37 @@
+#
+# CodeQL Workflow for libseccomp
+#
+# Copyright (c) 2022 Microsoft Corporation <paulmoore@microsoft.com>
+# Author: Paul Moore <paul@paul-moore.com>
+#
+
+name: "CodeQL"
+on: ["push", "pull_request"]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp', 'python' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Initialize libseccomp
+      uses: ./.github/actions/setup
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
This enables the GitHub "Security / Code Scanning" tool using CodeQL.

 * https://github.com/seccomp/libseccomp/security

Signed-off-by: Paul Moore <paul@paul-moore.com>