### PR TITLE
BUG: add link to oss-security to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,3 +43,4 @@ followed, including notification to the linux-distros and oss-security mailing
 lists.
 
 * https://oss-security.openwall.org/wiki/mailing-lists/distros
+* https://oss-security.openwall.org/wiki/mailing-lists/oss-security


### PR DESCRIPTION
The text mentions two mailing lists, distros and oss-security, but only
provides a link to distros.

Add a link to oss-security.