### PR TITLE
BUG: fix 54-live-binary_tree to use binary tree

### DIFF
--- a/tests/54-live-binary_tree.c
+++ b/tests/54-live-binary_tree.c
@@ -30,7 +30,6 @@
 
 #include "util.h"
 
-/* arbitrary list of syscalls to force seccomp to generate a binary tree */
 static const int denylist[] = {
 	SCMP_SYS(times),
 	SCMP_SYS(ptrace),
@@ -87,6 +86,9 @@ int main(int argc, char *argv[])
 	if (ctx == NULL)
 		return ENOMEM;
 
+        rc = seccomp_attr_set(ctx, SCMP_FLTATR_CTL_OPTIMIZE, 2);
+        if (rc < 0)
+                goto out;
 	rc = seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(write), 1,
 			      SCMP_A0(SCMP_CMP_EQ, fd));
 	if (rc != 0)

--- a/tests/54-live-binary_tree.py
+++ b/tests/54-live-binary_tree.py
@@ -62,6 +62,7 @@ def test():
     util.install_trap()
     f = SyscallFilter(TRAP)
     f.set_attr(Attr.CTL_TSYNC, 1)
+    f.set_attr(Attr.CTL_OPTIMIZE, 2)
     # NOTE: additional syscalls required for python
     f.add_rule(ALLOW, "stat")
     f.add_rule(ALLOW, "fstat")


### PR DESCRIPTION
Apparently, an early implementation of the binary tree optimization
used to enable the feature when the number of rules added was > 16.

The code was later changed to add and use SCMP_FLTATR_CTL_OPTIMIZE,
but the 54-live-binary_tree test case was left as is. So, despite
its name, it is not testing the binary tree.

Fix this, and remove the comment that referred to the old
implementation.

Fixes: 38f04da8 (PR #152)
Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>