### PR TITLE
BUG: Python distutils is deprecated

### DIFF
--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -23,9 +23,9 @@
 
 import os
 
-from distutils.core import setup
-from distutils.extension import Extension
-from Cython.Distutils import build_ext
+from setuptools import setup
+from setuptools.extension import Extension
+from Cython.Build import cythonize
 
 setup(
 	name = "seccomp",
@@ -37,12 +37,9 @@ setup(
 	maintainer_email = "paul@paul-moore.com",
 	license = "LGPLv2.1",
 	platforms = "Linux",
-	cmdclass = {'build_ext': build_ext},
-	ext_modules = [
+	ext_modules = cythonize([
 		Extension("seccomp", ["seccomp.pyx"],
 			# unable to handle libtool libraries directly
-			extra_objects=["../.libs/libseccomp.a"],
-			# fix build warnings, see PEP 3123
-			extra_compile_args=["-fno-strict-aliasing"])
-	]
+			extra_objects=["../.libs/libseccomp.a"]),
+	])
 )


### PR DESCRIPTION
The python distutils package is deprecated.  Utilize
setuptools and cythonize instead.

	./setup.py:26: DeprecationWarning: The distutils
	package is deprecated and slated for removal in
	Python 3.12. Use setuptools or check PEP 632 [1] for
	potential alternatives

[1] https://peps.python.org/pep-0632/

Fixes: https://github.com/seccomp/libseccomp/issues/372
Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>