### PR TITLE
RFE: remove the mailing list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,47 +113,8 @@ your real name, saying:
 
 You can add this to your commit description in `git` with `git commit -s`
 
-## Post Your Patches Upstream
+## Post Your Patches to GitHub
 
-The libseccomp project accepts both GitHub pull requests and patches sent via
-the mailing list.  GitHub pull requests are preferred.  This sections below
-explain how to contribute via either method. Please read each step and perform
-all steps that apply to your chosen contribution method.
-
-### Submitting via Email
-
-Depending on how you decided to work with the libseccomp code base and what
-tools you are using there are different ways to generate your patch(es).
-However, regardless of what tools you use, you should always generate your
-patches using the "unified" diff/patch format and the patches should always
-apply to the libseccomp source tree using the following command from the top
-directory of the libseccomp sources:
-
-	# patch -p1 < changes.patch
-
-If you are not using git, stacked git (stgit), or some other tool which can
-generate patch files for you automatically, you may find the following command
-helpful in generating patches, where "libseccomp.orig/" is the unmodified
-source code directory and "libseccomp/" is the source code directory with your
-changes:
-
-	# diff -purN libseccomp.orig/ libseccomp/
-
-When in doubt please generate your patch and try applying it to an unmodified
-copy of the libseccomp sources; if it fails for you, it will fail for the rest
-of us.
-
-Finally, you will need to email your patches to the mailing list so they can
-be reviewed and potentially merged into the main libseccomp repository.  When
-sending patches to the mailing list it is important to send your email in text
-form, no HTML mail please, and ensure that your email client does not mangle
-your patches.  It should be possible to save your raw email to disk and apply
-it directly to the libseccomp source code; if that fails then you likely have
-a problem with your email client.  When in doubt try a test first by sending
-yourself an email with your patch and attempting to apply the emailed patch to
-the libseccomp repository; if it fails for you, it will fail for the rest of
-us trying to test your patch and include it in the main libseccomp repository.
-
-### Submitting via GitHub
-
-See [this guide](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) if you've never done this before.
+The libseccomp project accepts new patches via GitHub pull requests, if you
+are not familiar with GitHub pull requests please see
+[this guide](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request).

--- a/README.md
+++ b/README.md
@@ -24,13 +24,6 @@ URL:
 
 * https://github.com/seccomp/libseccomp-golang
 
-The project mailing list is currently hosted on Google Groups at the URL below,
-please note that a Google account is not required to subscribe to the mailing
-list.
-
-* https://groups.google.com/forum/#!forum/libseccomp
-* https://groups.google.com/forum/#!forum/libseccomp/join
-
 ## Supported Architectures
 
 The libseccomp library currently supports the architectures listed below:
@@ -133,5 +126,5 @@ these tools are installed by default.
 ## Bug and Vulnerability Reporting
 
 Problems with the libseccomp library can be reported using the GitHub issue
-tracking system or the mailing list.  Those who wish to privately report
-potential vulnerabilities should follow the directions in SECURITY.md.
+tracking system.  Those who wish to privately report potential vulnerabilities
+should follow the directions in SECURITY.md.

--- a/doc/admin/MAINTAINER_PROCESS.md
+++ b/doc/admin/MAINTAINER_PROCESS.md
@@ -74,17 +74,6 @@ the next major/minor release (for example, v2.5), and one for the next patch
 release (for example, v2.4.2).  As issues are entered into the system, they can
 be added to the milestones at the discretion of the maintainers.
 
-### Managing the Public Mailing List
-
-The mailing list is currently hosted on Google Groups, and while it is possible
-to participate in discussions without a Google account, a Google account is
-required to moderate/administer the group.  Those maintainers who do have a
-Google account and wish to be added to the moderators list should be added, but
-there is no requirement to do so.
-
-Despite the term "moderator" the list is currently unmoderated and should
-remain the way.
-
 ### Handling Inappropriate Community Behavior
 
 The libseccomp project community is relatively small, and almost always


### PR DESCRIPTION
Ever since the move to GH, the mailing list hasn't been very useful or very popular so let's just drop it.

Signed-off-by: Paul Moore <paul@paul-moore.com>