### PR TITLE
RFE: arch: shell fixes

### DIFF
--- a/src/arch-syscall-validate
+++ b/src/arch-syscall-validate
@@ -845,10 +845,6 @@ while getopts "a:c:slh" opt; do
 		opt_lib=0
 		;;
 	l)
-		if [[ ! -x $LIB_SYS_DUMP ]]; then
-			echo "error: \"$LIB_SYS_DUMP\" is not present"
-			exit 1
-		fi
 		opt_sys=0
 		opt_lib=1
 		;;
@@ -880,6 +876,11 @@ if [[ -z $kernel_dir ]]; then
 fi
 if [[ ! -d $kernel_dir ]]; then
 	echo "error: \"$1\" is not a valid directory"
+	exit 1
+fi
+
+if [[ ! -x "$LIB_SYS_DUMP" ]]; then
+	echo "error: \"$LIB_SYS_DUMP\" is not present"
 	exit 1
 fi
 

--- a/src/arch-syscall-validate
+++ b/src/arch-syscall-validate
@@ -782,9 +782,9 @@ function gen_csv() {
 		eval output_$abi=$(mktemp -t syscall_validate_XXXXXX)
 		dump_$2_$abi "$1" > $(eval echo $`eval echo output_$abi`)
 	done
-	sc_list=$((for abi in $abi_list; do
+	sc_list=$( (for abi in $abi_list; do
 			cat $(eval echo $`eval echo output_$abi`);
-		   done) | awk -F "," '{ print $1 }' | sort -u)
+		    done) | awk -F "," '{ print $1 }' | sort -u)
 
 	# redirect the subshell to the csv file
 	(


### PR DESCRIPTION
Please see individual commit for details. Those are mostly nitpicks except for the `arch: require arch-syscall-dump from arch-syscall-validate` commit.