### PR TITLE
BUG: spelling fixes

### DIFF
--- a/include/seccomp.h.in
+++ b/include/seccomp.h.in
@@ -421,7 +421,7 @@ const struct scmp_version *seccomp_version(void);
  *  3 : support for the SCMP_FLTATR_CTL_LOG filter attribute
  *      support for the SCMP_ACT_LOG action
  *      support for the SCMP_ACT_KILL_PROCESS action
- *  4 : support for the SCMP_FLTATR_CTL_SSB filter attrbute
+ *  4 : support for the SCMP_FLTATR_CTL_SSB filter attribute
  *  5 : support for the SCMP_ACT_NOTIFY action and notify APIs
  *  6 : support the simultaneous use of SCMP_FLTATR_CTL_TSYNC and notify APIs
  *

--- a/src/arch-syscall-validate
+++ b/src/arch-syscall-validate
@@ -736,7 +736,7 @@ function dump_lib() {
 #     2    "sys" or "lib" depending on the syscall list to use
 #     3    csv file to use as input for saved fields
 #
-#   Generare a syscall csv file from the given kernel sources.
+#   Generate a syscall csv file from the given kernel sources.
 #
 function gen_csv() {
 


### PR DESCRIPTION
Fix a couple of typos. The first one is causing current CI to fail (I guess due to a newer version of codespell), the second one I spotted when reading the code.