### PR TITLE
RFE: add seccomp_precompute() to the API

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -33,6 +33,7 @@ dist_man3_MANS = \
 	man/man3/seccomp_init.3 \
 	man/man3/seccomp_load.3 \
 	man/man3/seccomp_merge.3 \
+	man/man3/seccomp_precompute.3 \
 	man/man3/seccomp_release.3 \
 	man/man3/seccomp_reset.3 \
 	man/man3/seccomp_rule_add.3 \

--- a/doc/man/man3/seccomp_precompute.3
+++ b/doc/man/man3/seccomp_precompute.3
@@ -1,8 +1,8 @@
-.TH "seccomp_load" 3 "30 May 2020" "paul@paul-moore.com" "libseccomp Documentation"
+.TH "seccomp_precompute" 3 "19 September 2022" "paul@paul-moore.com" "libseccomp Documentation"
 .\" //////////////////////////////////////////////////////////////////////////
 .SH NAME
 .\" //////////////////////////////////////////////////////////////////////////
-seccomp_load \- Load the current seccomp filter into the kernel
+seccomp_precompute \- Precompute the current seccomp filter
 .\" //////////////////////////////////////////////////////////////////////////
 .SH SYNOPSIS
 .\" //////////////////////////////////////////////////////////////////////////
@@ -11,7 +11,7 @@ seccomp_load \- Load the current seccomp filter into the kernel
 .sp
 .B typedef void * scmp_filter_ctx;
 .sp
-.BI "int seccomp_load(scmp_filter_ctx " ctx ");"
+.BI "int seccomp_precompute(scmp_filter_ctx " ctx ");"
 .sp
 Link with \fI\-lseccomp\fP.
 .fi
@@ -19,24 +19,12 @@ Link with \fI\-lseccomp\fP.
 .SH DESCRIPTION
 .\" //////////////////////////////////////////////////////////////////////////
 .P
-Loads the seccomp filter provided by
-.I ctx
-into the kernel; if the function
-succeeds the new seccomp filter will be active when the function returns.  If
-.BR seccomp_precompute (3)
-was called prior to attempting to load the seccomp filter, and no changes have
-been made to the filter,
+Precomputes the seccomp filter for later use by
 .BR seccomp_load ()
-can be considered to be async-signal-safe.
-.P
-As it is possible to have multiple stacked seccomp filters for a given task
-(defined as either a process or a thread), it is important to remember that
-each of the filters loaded for a given task are executed when a syscall is
-made and the "strictest" rule is the rule that is applied.  In the case of
-seccomp, "strictest" is defined as the action with the lowest value (e.g.
-.I SCMP_ACT_KILL
-is "stricter" than
-.IR SCMP_ACT_ALLOW ).
+and similar functions.  Not only does this improve performance of
+.BR seccomp_load ()
+it also ensures that the seccomp filter can be loaded in an async-signal-safe
+manner if no changes have been made to the filter since it was precomputed.
 .\" //////////////////////////////////////////////////////////////////////////
 .SH RETURN VALUE
 .\" //////////////////////////////////////////////////////////////////////////
@@ -53,9 +41,6 @@ Invalid input, either the context or architecture token is invalid.
 .TP
 .B -ENOMEM
 The library was unable to allocate enough memory.
-.TP
-.B -ESRCH
-Unable to load the filter due to thread issues.
 .P
 If the \fISCMP_FLTATR_API_SYSRAWRC\fP filter attribute is non-zero then
 additional error codes may be returned to the caller; these additional error
@@ -74,6 +59,12 @@ int main(int argc, char *argv[])
 
 	ctx = seccomp_init(SCMP_ACT_KILL);
 	if (ctx == NULL)
+		goto out;
+
+	/* ... */
+
+	rc = seccomp_precompute(ctx);
+	if (rc < 0)
 		goto out;
 
 	/* ... */
@@ -108,10 +99,5 @@ Paul Moore <paul@paul-moore.com>
 .\" //////////////////////////////////////////////////////////////////////////
 .SH SEE ALSO
 .\" //////////////////////////////////////////////////////////////////////////
-.BR seccomp_init (3),
-.BR seccomp_reset (3),
-.BR seccomp_release (3),
-.BR seccomp_rule_add (3),
-.BR seccomp_rule_add_exact (3)
-.BR seccomp_precompute (3)
+.BR seccomp_load (3)
 .BR signal-safety (7)

--- a/include/seccomp.h.in
+++ b/include/seccomp.h.in
@@ -830,6 +830,17 @@ int seccomp_export_bpf(const scmp_filter_ctx ctx, int fd);
  */
 int seccomp_export_bpf_mem(const scmp_filter_ctx ctx, void *buf, size_t *len);
 
+/**
+ * Precompute the seccomp filter for future use
+ * @param ctx the filter context
+ *
+ * This function precomputes the seccomp filter and stores it internally for
+ * future use, speeding up seccomp_load() and other functions which require
+ * the generated filter.
+ *
+ */
+int seccomp_precompute(const scmp_filter_ctx ctx);
+
 /*
  * pseudo syscall definitions
  */

--- a/src/db.c
+++ b/src/db.c
@@ -654,7 +654,7 @@ prune_next_node:
 		x_iter = x_iter_next;
 	} while (x_iter);
 
-	// if we are falling through, we clearly didn't match on anything
+	/* if we are falling through, we clearly didn't match on anything */
 	state_new.flags &= ~_DB_IST_MATCH;
 
 prune_return:

--- a/src/db.h
+++ b/src/db.h
@@ -2,6 +2,7 @@
  * Enhanced Seccomp Filter DB
  *
  * Copyright (c) 2012,2016 Red Hat <pmoore@redhat.com>
+ * Copyright (c) 2022 Microsoft Corporation <paulmoore@microsoft.com>
  * Author: Paul Moore <paul@paul-moore.com>
  */
 
@@ -28,6 +29,7 @@
 #include <seccomp.h>
 
 #include "arch.h"
+#include "gen_bpf.h"
 
 /* XXX - need to provide doxygen comments for the types here */
 
@@ -162,6 +164,9 @@ struct db_filter_col {
 
 	/* userspace notification */
 	bool notify_used;
+
+	/* precomputed programs */
+	struct bpf_program *prgm_bpf;
 };
 
 /**
@@ -211,6 +216,9 @@ int db_col_syscall_priority(struct db_filter_col *col,
 int db_col_transaction_start(struct db_filter_col *col);
 void db_col_transaction_abort(struct db_filter_col *col);
 void db_col_transaction_commit(struct db_filter_col *col);
+
+int db_col_precompute(struct db_filter_col *col);
+void db_col_precompute_reset(struct db_filter_col *col);
 
 int db_rule_add(struct db_filter *db, const struct db_api_rule_list *rule);
 

--- a/src/python/libseccomp.pxd
+++ b/src/python/libseccomp.pxd
@@ -170,5 +170,7 @@ cdef extern from "seccomp.h":
     int seccomp_export_bpf_mem(const scmp_filter_ctx ctx, void *buf,
                                size_t *len)
 
+    int seccomp_precompute(const scmp_filter_ctx ctx)
+
 # kate: syntax python;
 # kate: indent-mode python; space-indent on; indent-width 4; mixedindent off;

--- a/src/python/seccomp.pyx
+++ b/src/python/seccomp.pyx
@@ -1069,5 +1069,17 @@ cdef class SyscallFilter:
             raise RuntimeError(str.format("Library error (errno = {0})", rc))
         return program
 
+    def precompute(self):
+        """ Precompute the seccomp filter.
+
+        Description:
+        Precompute the seccomp filter and store it internally for future use,
+        speeding up filter loads and other functions which require the
+        generated filter.
+        """
+        rc = libseccomp.seccomp_precompute(self._ctx)
+        if rc != 0:
+            raise RuntimeError(str.format("Library error (errno = {0})", rc))
+
 # kate: syntax python;
 # kate: indent-mode python; space-indent on; indent-width 4; mixedindent off;

--- a/src/system.c
+++ b/src/system.c
@@ -360,9 +360,10 @@ int sys_filter_load(struct db_filter_col *col, bool rawrc)
 	bool listener_req;
 	struct bpf_program *prgm = NULL;
 
-	rc = gen_bpf_generate(col, &prgm);
+	rc = db_col_precompute(col);
 	if (rc < 0)
 		return rc;
+	prgm = col->prgm_bpf;
 
 	/* attempt to set NO_NEW_PRIVS */
 	if (col->attr.nnp_enable) {
@@ -417,7 +418,6 @@ int sys_filter_load(struct db_filter_col *col, bool rawrc)
 
 filter_load_out:
 	/* cleanup and return */
-	gen_bpf_release(prgm);
 	if (rc == -ESRCH)
 		return -ESRCH;
 	if (rc < 0)

--- a/tests/60-sim-precompute.c
+++ b/tests/60-sim-precompute.c
@@ -1,0 +1,68 @@
+/**
+ * Seccomp Library test program
+ *
+ * Copyright (c) 2022 Microsoft Corporation <paulmoore@microsoft.com>
+ * Author: Paul Moore <paul@paul-moore.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include <errno.h>
+#include <unistd.h>
+
+#include <seccomp.h>
+
+#include "util.h"
+
+int main(int argc, char *argv[])
+{
+	int rc;
+	struct util_options opts;
+	scmp_filter_ctx ctx = NULL;
+
+	rc = util_getopt(argc, argv, &opts);
+	if (rc < 0)
+		goto out;
+
+	ctx = seccomp_init(SCMP_ACT_ALLOW);
+	if (ctx == NULL)
+		return ENOMEM;
+
+	rc = seccomp_precompute(ctx);
+	if (rc != 0)
+		goto out;
+	rc = seccomp_rule_add_exact(ctx, SCMP_ACT_KILL, 1000, 0);
+	if (rc != 0)
+		goto out;
+
+	rc = seccomp_precompute(ctx);
+	if (rc != 0)
+		goto out;
+	rc = seccomp_rule_add_exact(ctx, SCMP_ACT_KILL, 1001, 0);
+	if (rc != 0)
+		goto out;
+
+	rc = seccomp_precompute(ctx);
+	if (rc != 0)
+		goto out;
+
+	rc = util_filter_output(&opts, ctx);
+	if (rc)
+		goto out;
+
+out:
+	seccomp_release(ctx);
+	return (rc < 0 ? -rc : rc);
+}

--- a/tests/60-sim-precompute.py
+++ b/tests/60-sim-precompute.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+#
+# Seccomp Library test program
+#
+# Copyright (c) 2012 Red Hat <pmoore@redhat.com>
+# Author: Paul Moore <paul@paul-moore.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+import argparse
+import sys
+
+import util
+
+from seccomp import *
+
+def test(args):
+    f = SyscallFilter(ALLOW)
+    f.precompute()
+    f.add_rule_exactly(KILL, 1000)
+    f.precompute()
+    f.add_rule_exactly(KILL, 1001)
+    f.precompute()
+    return f
+
+args = util.get_opt()
+ctx = test(args)
+util.filter_output(args, ctx)
+
+# kate: syntax python;
+# kate: indent-mode python; space-indent on; indent-width 4; mixedindent off;

--- a/tests/60-sim-precompute.tests
+++ b/tests/60-sim-precompute.tests
@@ -1,0 +1,23 @@
+#
+# libseccomp regression test automation data
+#
+# Copyright (c) 2022 Microsoft Corporation <paulmoore@microsoft.com>
+# Author: Paul Moore <paul@paul-moore.com>
+#
+
+test type: bpf-sim
+
+# Testname		Arch	Syscall	Arg0	Arg1	Arg2	Arg3	Arg4	Arg5	Result
+60-sim-precompute	all	0-10	N	N	N	N	N	N	ALLOW
+60-sim-precompute	all	1000	N	N	N	N	N	N	KILL
+60-sim-precompute	all	1001	N	N	N	N	N	N	KILL
+
+test type: bpf-sim-fuzz
+
+# Testname		StressCount
+60-sim-precompute	5
+
+test type: bpf-valgrind
+
+# Testname
+60-sim-precompute

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -94,7 +94,8 @@ check_PROGRAMS = \
 	56-basic-iterate_syscalls \
 	57-basic-rawsysrc \
 	58-live-tsync_notify \
-	59-basic-empty_binary_tree
+	59-basic-empty_binary_tree \
+	60-sim-precompute
 
 EXTRA_DIST_TESTPYTHON = \
 	util.py \
@@ -154,7 +155,8 @@ EXTRA_DIST_TESTPYTHON = \
 	56-basic-iterate_syscalls.py \
 	57-basic-rawsysrc.py \
 	58-live-tsync_notify.py \
-	59-basic-empty_binary_tree.py
+	59-basic-empty_binary_tree.py \
+	60-sim-precompute.py
 
 EXTRA_DIST_TESTCFGS = \
 	01-sim-allow.tests \
@@ -215,7 +217,8 @@ EXTRA_DIST_TESTCFGS = \
 	56-basic-iterate_syscalls.tests \
 	57-basic-rawsysrc.tests \
 	58-live-tsync_notify.tests \
-	59-basic-empty_binary_tree.tests
+	59-basic-empty_binary_tree.tests \
+	60-sim-precompute.tests
 
 EXTRA_DIST_TESTSCRIPTS = \
 	38-basic-pfc_coverage.sh 38-basic-pfc_coverage.pfc \


### PR DESCRIPTION
This patch adds a seccomp_precompute() API to precompute the seccomp filter prior to calling seccomp_load() or similar functions.  Not only does this improve the performance of seccomp_load(), it ensures that seccomp_load() is async-signal-safe if no additional changes have been made since the filter was precomputed.

Resolves #123