### PR TITLE
RFE: link python against shared library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -120,7 +120,7 @@ AS_IF([test "$enable_python" = yes], [
 ])
 AM_CONDITIONAL([ENABLE_PYTHON], [test "$enable_python" = yes])
 AC_DEFINE_UNQUOTED([ENABLE_PYTHON],
-	[$(test "$enable_python" = yes && echo 1 || echo 0)],
+	[$(test "$enable_python" = "yes" && echo 1 || echo 0)],
 	[Python bindings build flag.])
 
 AC_CHECK_TOOL(GPERF, gperf)

--- a/configure.ac
+++ b/configure.ac
@@ -95,9 +95,11 @@ dnl cython checks
 dnl ####
 AC_CHECK_PROGS(cython, cython3 cython, "no")
 AS_IF([test "$cython" != no], [
-	AS_ECHO("checking cython version... $($cython -V 2>&1 | cut -d' ' -f 3)")
-	CYTHON_VER_MAJ=$($cython -V 2>&1 | cut -d' ' -f 3 | cut -d'.' -f 1);
-	CYTHON_VER_MIN=$($cython -V 2>&1 | cut -d' ' -f 3 | cut -d'.' -f 2);
+	AC_MSG_CHECKING([cython version])
+	CYTHON_VER_FULL=$(cython -V 2>&1 | cut -d' ' -f 3);
+	CYTHON_VER_MAJ=$(echo $CYTHON_VER_FULL | cut -d'.' -f 1);
+	CYTHON_VER_MIN=$(echo $CYTHON_VER_FULL | cut -d'.' -f 2);
+	AC_MSG_RESULT([$CYTHON_VER_FULL])
 ],[
 	CYTHON_VER_MAJ=0
 	CYTHON_VER_MIN=0

--- a/src/arch-syscall-check
+++ b/src/arch-syscall-check
@@ -22,8 +22,11 @@
 # along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
-SYSCALL_CSV="./syscalls.csv"
-SYSCALL_HDR="../include/seccomp-syscalls.h"
+# Based on an idea from GNU coreutils
+abs_topsrcdir="$(unset CDPATH; cd $(dirname $0)/.. && pwd)"
+
+SYSCALL_CSV="$abs_topsrcdir/src/syscalls.csv"
+SYSCALL_HDR="$abs_topsrcdir/include/seccomp-syscalls.h"
 
 function check_snr() {
 	(export LC_ALL=C; diff \

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -39,7 +39,7 @@ setup(
 	platforms = "Linux",
 	ext_modules = cythonize([
 		Extension("seccomp", ["seccomp.pyx"],
-			# unable to handle libtool libraries directly
-			extra_objects=["../.libs/libseccomp.a"]),
+			library_dirs=["../.libs"],
+			libraries=["seccomp"]),
 	])
 )

--- a/tests/regression
+++ b/tests/regression
@@ -1010,6 +1010,9 @@ function run_tests() {
 	local -a job_pids
 	local -a job_logs
 
+	# Allow tests to find freshly built library
+	export LD_LIBRARY_PATH="../src/.libs:$LD_LIBRARY_PATH"
+
 	# loop through all test files
 	for file in $basedir/*.tests; do
 		local batch_requested=false


### PR DESCRIPTION
Honestly, I have no idea why libseccomp is linked into the python module statically. With dynamic linking we can decrease overall memory consumption (as the shared object is loaded in the memory just once) - just like with regular binaries that link to libseccomp.