### PR TITLE
BUG: Fix Node.js 12 deprecation warnings

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Initialize libseccomp
       uses: ./.github/actions/setup
     - name: Initialize CodeQL

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout from github
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Initialize libseccomp
       uses: ./.github/actions/setup
     - name: Build libseccomp
@@ -47,7 +47,7 @@ jobs:
 
     steps:
     - name: Checkout from github
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Initialize libseccomp
       uses: ./.github/actions/setup
     - name: Build libseccomp
@@ -66,7 +66,7 @@ jobs:
 
     steps:
     - name: Checkout from github
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Initialize libseccomp
       uses: ./.github/actions/setup
     - name: Run scan-build
@@ -80,7 +80,7 @@ jobs:
 
     steps:
     - name: Checkout from github
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Initialize libseccomp
       uses: ./.github/actions/setup
     - name: Configure libseccomp
@@ -111,7 +111,7 @@ jobs:
 
     steps:
     - name: Checkout from github
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Spellcheck
       uses: codespell-project/actions-codespell@master
       with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -98,7 +98,7 @@ jobs:
         flag-name: "amd64"
     - name: Archive code coverage results
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Code Coverage Artifacts
         path: |


### PR DESCRIPTION
Fix several Node.js 12 deprecation warnings in our github actions.  Note that the coveralls action still has the deprecation warning [1] and the fix must be done within their plugin.

[1] https://github.com/coverallsapp/github-action/issues/132