### PR TITLE
RFE: github: Add dependency checker action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+#
+# Dependabot Workflow for libseccomp
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+# based on this guide from GitHub:
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+    commit-message:
+      prefix: "RFE:"
+    labels:
+      - "enhancement"
+      - "priority/low"


### PR DESCRIPTION
Add an action, dependabot, that will periodically check GitHub Actions dependencies.  It is currently configured to run weekly.  If dependabot finds an update, it will open a pull request.

See here for more details:
	https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>