### PR TITLE
RFE: doc: Update code quality badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ https://github.com/seccomp/libseccomp
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/608/badge)](https://bestpractices.coreinfrastructure.org/projects/608)
 [![Build Status](https://github.com/seccomp/libseccomp/workflows/Continuous%20Integration/badge.svg?branch=main)](https://github.com/seccomp/libseccomp/actions)
 [![Coverage Status](https://img.shields.io/coveralls/github/seccomp/libseccomp/main.svg)](https://coveralls.io/github/seccomp/libseccomp?branch=main)
-[![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/seccomp/libseccomp.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/seccomp/libseccomp/context:cpp)
+[CodeQL Analysis](https://github.com/seccomp/libseccomp/actions/workflows/codeql-analysis.yml/badge.svg?branch=main)
 
 The libseccomp library provides an easy to use, platform independent, interface
 to the Linux Kernel's syscall filtering mechanism.  The libseccomp API is


### PR DESCRIPTION
LGTM is now deprecated [1].  Remove the LGTM badge and replace it with a CodeQL badge.

[1] https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/

Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>