### PR TITLE
BUG: docs: fix typo in seccomp_rule_add manpage

### DIFF
--- a/doc/man/man3/seccomp_rule_add.3
+++ b/doc/man/man3/seccomp_rule_add.3
@@ -222,7 +222,7 @@ When a filter utilizing
 is loaded into the kernel, the kernel generates a notification fd that must be
 used to communicate between the monitoring process and the process(es) being
 filtered.  See
-.B seccomp_notif_fd (3)
+.B seccomp_notify_fd (3)
 for more information.
 
 .P


### PR DESCRIPTION
Fix reference to seccomp_notify_fd manpage.