### PR TITLE
BUG: fix a missing SH arch removal in tests/16-sim-arch

### DIFF
--- a/tests/16-sim-arch_basic.c
+++ b/tests/16-sim-arch_basic.c
@@ -171,6 +171,9 @@ int main(int argc, char *argv[])
 	rc = seccomp_arch_remove(ctx, SCMP_ARCH_RISCV64);
 	if (rc != 0)
 		goto out;
+	rc = seccomp_arch_remove(ctx, SCMP_ARCH_SH);
+	if (rc != 0)
+		goto out;
 
 out:
 	seccomp_release(ctx);


### PR DESCRIPTION
`seccomp_arch_remove()` for `SCMP_ARCH_SH` is missing, so add it.