### PR TITLE
BUG: fix test failure on LoongArch

### DIFF
--- a/src/arch-syscall-dump.c
+++ b/src/arch-syscall-dump.c
@@ -111,6 +111,7 @@ int main(int argc, char *argv[])
 			break;
 		case SCMP_ARCH_LOONGARCH64:
 			sys = loongarch64_syscall_iterate(iter);
+			break;
 		case SCMP_ARCH_M68K:
 			sys = m68k_syscall_iterate(iter);
 			break;

--- a/tools/scmp_arch_detect.c
+++ b/tools/scmp_arch_detect.c
@@ -83,6 +83,7 @@ int main(int argc, char *argv[])
 			break;
 		case SCMP_ARCH_LOONGARCH64:
 			printf("loongarch64\n");
+			break;
 		case SCMP_ARCH_M68K:
 			printf("m68k\n");
 			break;


### PR DESCRIPTION
When adding m68k architecture, break was lost.