### PR TITLE
BUG: mention SCMP_ARCH_{M68K,SH,SHEB} in seccomp_arch_add(3)

### DIFF
--- a/doc/man/man3/seccomp_arch_add.3
+++ b/doc/man/man3/seccomp_arch_add.3
@@ -18,6 +18,7 @@ seccomp_arch_add, seccomp_arch_remove, seccomp_arch_exist, seccomp_arch_native \
 .B #define SCMP_ARCH_ARM
 .B #define SCMP_ARCH_AARCH64
 .B #define SCMP_ARCH_LOONGARCH64
+.B #define SCMP_ARCH_M68K
 .B #define SCMP_ARCH_MIPS
 .B #define SCMP_ARCH_MIPS64
 .B #define SCMP_ARCH_MIPS64N32
@@ -29,6 +30,8 @@ seccomp_arch_add, seccomp_arch_remove, seccomp_arch_exist, seccomp_arch_native \
 .B #define SCMP_ARCH_PPC64LE
 .B #define SCMP_ARCH_S390
 .B #define SCMP_ARCH_S390X
+.B #define SCMP_ARCH_SH
+.B #define SCMP_ARCH_SHEB
 .B #define SCMP_ARCH_PARISC
 .B #define SCMP_ARCH_PARISC64
 .B #define SCMP_ARCH_RISCV64


### PR DESCRIPTION
Fixes: dd5c9c24e8ba ("arch: Add 32-bit Motorola 68000 support")
Fixes: c12945db0b7e ("arch: Add SuperH 32-bit support")
Similar to: https://github.com/seccomp/libseccomp/commit/76e3689dc851ff740ded38f8c623cfbce3bad393 ("doc: mention SCMP_ARCH_LOONGARCH64 in seccomp_arch_add(3)")