### PR TITLE
BUG: fix detection of WAIT_KILLABLE_RECV flag

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -311,8 +311,16 @@ int sys_chk_seccomp_flag(int flag)
 			state.sup_flag_tsync_esrch = _sys_chk_flag_kernel(flag);
 		return state.sup_flag_tsync_esrch;
 	case SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV:
-		if (state.sup_flag_wait_kill < 0)
-			state.sup_flag_wait_kill = _sys_chk_flag_kernel(flag|SECCOMP_FILTER_FLAG_NEW_LISTENER);
+		if (state.sup_flag_wait_kill < 0) {
+			/* kernel requires NEW_LISTENER with WAIT_KILLABLE_RECV */
+			flag |= SECCOMP_FILTER_FLAG_NEW_LISTENER;
+			sys_chk_seccomp_flag(SECCOMP_FILTER_FLAG_NEW_LISTENER);
+			if (state.sup_flag_new_listener) {
+				state.sup_flag_wait_kill = _sys_chk_flag_kernel(flag);
+			} else {
+				state.sup_flag_wait_kill = 0;
+			}
+		}
 		return state.sup_flag_wait_kill;
 	}
 

--- a/src/system.c
+++ b/src/system.c
@@ -312,7 +312,7 @@ int sys_chk_seccomp_flag(int flag)
 		return state.sup_flag_tsync_esrch;
 	case SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV:
 		if (state.sup_flag_wait_kill < 0)
-			state.sup_flag_wait_kill = _sys_chk_flag_kernel(flag);
+			state.sup_flag_wait_kill = _sys_chk_flag_kernel(flag|SECCOMP_FILTER_FLAG_NEW_LISTENER);
 		return state.sup_flag_wait_kill;
 	}
 


### PR DESCRIPTION
The kernel returns EINVAL when this flag is passed to seccomp without the new listener flag so we should pass this flag along as well.

Reference on where the check happens in the kernel:
https://github.com/torvalds/linux/blob/aea6bf908d730b01bd264a8821159db9463c111c/kernel/seccomp.c#L1926-L1932