### PR TITLE
BUG: fix check for SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV flag

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -192,7 +192,8 @@ static unsigned int _seccomp_api_update(void)
 		level = 6;
 
 	if (level == 6 &&
-	    sys_chk_seccomp_flag(SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV) == 1)
+	    sys_chk_seccomp_flag(SECCOMP_FILTER_FLAG_NEW_LISTENER |
+	                         SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV) == 1)
 		level = 7;
 
 	/* update the stored api level and return */

--- a/src/system.c
+++ b/src/system.c
@@ -310,7 +310,7 @@ int sys_chk_seccomp_flag(int flag)
 		if (state.sup_flag_tsync_esrch < 0)
 			state.sup_flag_tsync_esrch = _sys_chk_flag_kernel(flag);
 		return state.sup_flag_tsync_esrch;
-	case SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV:
+	case SECCOMP_FILTER_FLAG_NEW_LISTENER | SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV:
 		if (state.sup_flag_wait_kill < 0)
 			state.sup_flag_wait_kill = _sys_chk_flag_kernel(flag);
 		return state.sup_flag_wait_kill;


### PR DESCRIPTION
Testing for the SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV flag without also having the SECCOMP_FILTER_FLAG_NEW_LISTENER flag will return EINVAL instead of EFAULT.

The specific line in kernel/seccomp.c is:
```
	if ((flags & SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV) &&
	    ((flags & SECCOMP_FILTER_FLAG_NEW_LISTENER) == 0))
		return -EINVAL;
```

When checking for the seccomp api level, this will mean that level 7 will not be reached unless SECCOMP_FILTER_FLAG_NEW_LISTENER is included in the test.

Fixes: 96989965042a ("api: add the SCMP_FLTATR_CTL_WAITKILL filter attribute")