### PR TITLE
BUG: fix small syntax errors in the gperf script

### DIFF
--- a/src/arch-gperf-generate
+++ b/src/arch-gperf-generate
@@ -24,7 +24,7 @@ sys_csv_tmp=$(mktemp -t generate_syscalls_XXXXXX)
 # filter and prepare the syscall csv file
 cat $sys_csv | grep -v '^#' | nl -ba -s, -v0 | \
     sed -e '{s|^[[:space:]]\+\([0-9]\+\),\([^,]\+\),\(.*\)|\2,\1,\3|;};' \
-        -e '{:r1; {s|\([^,]\+\)\(.*\)[^_]PNR|\1\2,__PNR_\1|g;}; t r1};' \
+        -e '{:r1; {s|\([^,]\+\)\(.*\)[^_]PNR|\1\2,__PNR_\1|g;}; t r1;};' \
         -e '{s|,KV_|,SCMP_KV_|g;};' \
          > $sys_csv_tmp
 [[ $? -ne 0 ]] && exit 1


### PR DESCRIPTION
hi，when I compile libseccomp, the error is as follows:
```
  CC       libseccomp_la-syscalls.lo
  GEN      syscalls.perf
sed: can't find label for jump to 'r1}'
make[3]: *** [Makefile:1425: syscalls.perf] Error 1
make[3]: *** Waiting for unfinished jobs....
make[2]: *** [Makefile:935: all-recursive] Error 1
```

more detail：
```
~/test/libseccomp/src$ cat ./syscalls.csv | grep -v '^#'|nl -ba -s, -v0 | sed -e '{s|^[[:space:]]\+\([0-9]\+\),\([^,]\+\),\(.*\)|\2,\1,\3|;};' -e '{:r1; {s|\([^,]\+\)\(.*\)[^_]PNR|\1\2,__PNR_\1|g;}; t r1};' -e '{s|,KV_|,SCMP_KV_|g;};'
sed: can't find label for jump to 'r1}'
~/test/libseccomp/src$ 
```