### PR TITLE
BUG: fix ISO C compliance

### DIFF
--- a/include/seccomp.h.in
+++ b/include/seccomp.h.in
@@ -248,7 +248,7 @@ struct scmp_arg_cmp {
 #define SCMP_SYS(x)		(__SNR_##x)
 
 /* Helpers for the argument comparison macros, DO NOT USE directly */
-#define _SCMP_VA_NUM_ARGS(...)	_SCMP_VA_NUM_ARGS_IMPL(__VA_ARGS__,2,1)
+#define _SCMP_VA_NUM_ARGS(...)	_SCMP_VA_NUM_ARGS_IMPL(__VA_ARGS__,2,1,0)
 #define _SCMP_VA_NUM_ARGS_IMPL(_1,_2,N,...)	N
 #define _SCMP_MACRO_DISPATCHER(func, ...) \
 	_SCMP_MACRO_DISPATCHER_IMPL1(func, _SCMP_VA_NUM_ARGS(__VA_ARGS__))


### PR DESCRIPTION
When macro `_SCMP_VA_NUM_ARGS` is invoked with one argument, it expands to `_SCMP_VA_NUM_ARGS_IMPL` with only 3 arguments specified.

Compilers like gcc and clang support empty variadic macro argument as a language extension, however, in ISO C, at least one argument should be specified for the `...` argument of a function-like macro (See ISO/IEC 9899:1999 6.10.3(4)).

This patch should make the code more standard-compliant, and silences certain compiler warnings (e.g. clang `-Wgnu-zero-variadic-macro-arguments`)

Note: there are other non-standard code (e.g. void pointer arithmetic), but not addressed in this patch. It's okay for projects to use language extensions, but less so in public headers.