### PR TITLE
scmp_bpf_sim: fix aliasing UB

### DIFF
--- a/tools/scmp_bpf_sim.c
+++ b/tools/scmp_bpf_sim.c
@@ -182,7 +182,8 @@ static void bpf_execute(const struct bpf_program *prg,
 		switch (code) {
 		case BPF_LD+BPF_W+BPF_ABS:
 			if (k < BPF_SYSCALL_MAX) {
-				uint32_t val = *((uint32_t *)&sys_data_b[k]);
+				uint32_t val;
+				memcpy(&val, &sys_data_b[k], sizeof(val));
 				state.acc = ttoh32(arch, val);
 			} else
 				exit_error(ERANGE, ip_c);


### PR DESCRIPTION
See https://github.com/seccomp/libseccomp/pull/425.

Punning sys_data_b between uint32_t* and struct* seccomp_data isn't legal, use memcpy to fix the testsuite with Clang 17.

Modern compilers recognise this idiom and optimise it out anyway.