### PR TITLE
setup.py: /usr/bin/env python3

### DIFF
--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Enhanced Seccomp Library Python Module Build Script


### PR DESCRIPTION
python may not exist, or could be the python 2 interpreter.