### PR TITLE
RFE: Remove Github Actions dependency upon python3-distutils

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -29,7 +29,7 @@ runs:
   - run: sudo apt-get install -y build-essential valgrind clang-tools lcov gperf astyle codespell
     shell: bash
   - run: |
-      sudo apt-get install -y python3 python3-distutils python3-setuptools python3-pip
+      sudo apt-get install -y python3 python3-setuptools python3-pip
       python3 -m pip install --upgrade pip
       python3 -m pip install cython
       # Add cython to the path


### PR DESCRIPTION
The package python3-distutils has been deprecated, and we no longer depend upon it.  Don't install it during Github Actions automated tests.