### PR TITLE
BUG: remove the fuzzer from test 62-sim-arch_transactions

### DIFF
--- a/tests/62-sim-arch_transactions.tests
+++ b/tests/62-sim-arch_transactions.tests
@@ -14,11 +14,6 @@ test type: bpf-sim
 62-sim-arch_transactions	+x86_64	open		N	N	N	N	N	N	KILL
 62-sim-arch_transactions	+x86_64	close		N	N	N	N	N	N	ALLOW
 
-test type: bpf-sim-fuzz
-
-# Testname			StressCount
-62-sim-arch_transactions	5
-
 test type: bpf-valgrind
 
 # Testname


### PR DESCRIPTION
We can't reliably run the bpf-sim-fuzz tests on tests which manipulate the filters arch/ABIs unless the filter is safe to run on all arch/ABIs, which is more or less impossible.  Remove the bpf-sim-fuzz test section in test #62 to work around this, just as we do with the other similar tests.