### PR TITLE
BUG: fix seccomp_export_bpf_mem out-of-bounds read

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -786,7 +786,7 @@ API int seccomp_export_bpf_mem(const scmp_filter_ctx ctx, void *buf,
 		if (BPF_PGM_SIZE(program) > *len)
 			rc = _rc_filter(-ERANGE);
 		else
-			memcpy(buf, program->blks, *len);
+			memcpy(buf, program->blks, BPF_PGM_SIZE(program));
 	}
 	*len = BPF_PGM_SIZE(program);
 


### PR DESCRIPTION
`*len` is the length of the destination buffer, but `program->blks` is probably not anywhere near that long.  It's already been checked above that `BPF_PGM_SIZE(program)` is less than or equal to `*len`, so that's the correct value to use here to avoid either reading or writing too much.

I noticed this because tests/11-basic-basic_errors started failing on musl after e797591 ("all: add seccomp_precompute() functionality").