### PR TITLE
BUG: doc: mention EINVAL in seccomp_transaction_start(3)

### DIFF
--- a/doc/man/man3/seccomp_transaction_start.3
+++ b/doc/man/man3/seccomp_transaction_start.3
@@ -60,6 +60,9 @@ and
 functions return zero on success or one of the following error codes on
 failure:
 .TP
+.B -EINVAL
+The context is invalid.
+.TP
 .B -ENOMEM
 The library was unable to allocate enough memory.
 .\" //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Document the fact that both `seccomp_transaction_start` and `seccomp_transaction_commit` can return `-EINVAL` when `ctx` is invalid.