### PR TITLE
RFE: add License variable to pkg-config file

### DIFF
--- a/libseccomp.pc.in
+++ b/libseccomp.pc.in
@@ -30,3 +30,4 @@ URL: https://github.com/seccomp/libseccomp
 Version: @PACKAGE_VERSION@
 Cflags: -I${includedir}
 Libs: -L${libdir} -lseccomp
+License: LGPL-2.1-only


### PR DESCRIPTION
The pkg-config file has License variable that allows you to set the license for the software. 
This sets 'LGPL-2.1-or-later' as defined in SPDX to License.

Ref: https://github.com/pkgconf/pkgconf/blob/master/man/pc.5#L116