### PR TITLE
RFE: Add SCMP_ACT_TRAPX()

### DIFF
--- a/doc/man/man3/seccomp_init.3
+++ b/doc/man/man3/seccomp_init.3
@@ -67,12 +67,24 @@ The entire process will be terminated by the kernel with SIGSYS when it calls a
 syscall that does not match any of the configured seccomp filter rules.
 .TP
 .B SCMP_ACT_TRAP
+See
+.B SCMP_ACT_TRAPX
+.TP
+.B SCMP_ACT_TRAPX(unit16_t reason)
 The thread will be sent a SIGSYS signal when it calls a syscall that does not
 match any of the configured seccomp filter rules.  It may catch this and change
 its behavior accordingly.  When using SA_SIGINFO with
 .BR sigaction (2),
 si_code will be set to SYS_SECCOMP, si_syscall will be set to the syscall that
 failed the rules, and si_arch will be set to the AUDIT_ARCH for the active ABI.
+If
+.B SCMP_ACT_TRAPX
+is utilized,
+the si_errno field in
+.BR sigaction (2),
+will be set to
+.I reason
+.
 .TP
 .B SCMP_ACT_ERRNO(uint16_t errno)
 The thread will receive a return value of

--- a/doc/man/man3/seccomp_rule_add.3
+++ b/doc/man/man3/seccomp_rule_add.3
@@ -184,6 +184,13 @@ the filter rule.
 The thread will throw a SIGSYS signal when it calls a syscall that matches the
 filter rule.
 .TP
+.B SCMP_ACT_TRAPX(uint16_t reason)
+The thread will throw a SIGSYS signal when it calls a syscall that matches the
+filter rule. When using SA_SIGINFO with
+.BR sigaction (2),
+.I reason
+will be populated in the si_errno field.
+.TP
 .B SCMP_ACT_ERRNO(uint16_t errno)
 The thread will receive a return value of
 .I errno

--- a/include/seccomp.h.in
+++ b/include/seccomp.h.in
@@ -365,8 +365,12 @@ struct scmp_arg_cmp {
 #define SCMP_ACT_KILL		SCMP_ACT_KILL_THREAD
 /**
  * Throw a SIGSYS signal
+ *
+ * The Linux kernel supports a 16-bit parameter for the TRAP action, but
+ * libseccomp v2.6.x and older did not support or utilize this parameter.
  */
-#define SCMP_ACT_TRAP		0x00030000U
+#define SCMP_ACT_TRAP		SCMP_ACT_TRAPX(0)
+#define SCMP_ACT_TRAPX(x)	(0x00030000U | ((x) & 0x0000ffffU))
 /**
  * Notifies userspace
  */

--- a/src/gen_pfc.c
+++ b/src/gen_pfc.c
@@ -135,8 +135,8 @@ static void _pfc_action(FILE *fds, uint32_t action)
 	case SCMP_ACT_KILL_THREAD:
 		fprintf(fds, "action KILL;\n");
 		break;
-	case SCMP_ACT_TRAP:
-		fprintf(fds, "action TRAP;\n");
+	case SCMP_ACT_TRAPX(0):
+		fprintf(fds, "action TRAP(%u);\n", (action & 0x0000ffff));
 		break;
 	case SCMP_ACT_ERRNO(0):
 		fprintf(fds, "action ERRNO(%u);\n", (action & 0x0000ffff));

--- a/src/system.c
+++ b/src/system.c
@@ -196,7 +196,7 @@ int sys_chk_seccomp_action(uint32_t action)
 		return state.sup_kill_process;
 	} else if (action == SCMP_ACT_KILL_THREAD) {
 		return 1;
-	} else if (action == SCMP_ACT_TRAP) {
+	} else if (action == SCMP_ACT_TRAPX(action & 0x0000ffff)) {
 		return 1;
 	} else if ((action == SCMP_ACT_ERRNO(action & 0x0000ffff)) &&
 		   ((action & 0x0000ffff) < MAX_ERRNO)) {

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -70,3 +70,4 @@ util.pyc
 60-sim-precompute
 61-sim-transactions
 62-sim-arch_transactions
+63-live-trapx

--- a/tests/38-basic-pfc_coverage.pfc
+++ b/tests/38-basic-pfc_coverage.pfc
@@ -33,18 +33,18 @@ if ($arch == 3221225534)
                 if ($a2.hi32 == 0)
                   if ($a2.lo32 >= 2)
                   else
-                    action TRAP;
+                    action TRAP(0);
                 else
-                  action TRAP;
+                  action TRAP(0);
           else
             if ($a2.hi32 > 0)
             else
               if ($a2.hi32 == 0)
                 if ($a2.lo32 >= 2)
                 else
-                  action TRAP;
+                  action TRAP(0);
               else
-                action TRAP;
+                action TRAP(0);
     else
       if ($a1.hi32 > 0)
       else
@@ -56,18 +56,18 @@ if ($arch == 3221225534)
               if ($a2.hi32 == 0)
                 if ($a2.lo32 >= 2)
                 else
-                  action TRAP;
+                  action TRAP(0);
               else
-                action TRAP;
+                action TRAP(0);
         else
           if ($a2.hi32 > 0)
           else
             if ($a2.hi32 == 0)
               if ($a2.lo32 >= 2)
               else
-                action TRAP;
+                action TRAP(0);
             else
-              action TRAP;
+              action TRAP(0);
   # filter for syscall "read" (0) [priority: 65525]
   if ($syscall == 0)
     if ($a0.hi32 == 0)
@@ -123,7 +123,7 @@ if ($arch == 1073741827)
       else
         if ($a2 >= 2)
         else
-          action TRAP;
+          action TRAP(0);
   # filter for syscall "read" (3) [priority: 65531]
   if ($syscall == 3)
     if ($a0 == 0)
@@ -158,7 +158,7 @@ if ($arch == 3221225534)
       else
         if ($a2 >= 2)
         else
-          action TRAP;
+          action TRAP(0);
   # filter for syscall "read" (1073741824) [priority: 65531]
   if ($syscall == 1073741824)
     if ($a0 == 0)
@@ -193,7 +193,7 @@ if ($arch == 1073741864)
       else
         if ($a2 >= 2)
         else
-          action TRAP;
+          action TRAP(0);
   # filter for syscall "read" (3) [priority: 65531]
   if ($syscall == 3)
     if ($a0 == 0)
@@ -235,18 +235,18 @@ if ($arch == 3221225655)
                 if ($a2.hi32 == 0)
                   if ($a2.lo32 >= 2)
                   else
-                    action TRAP;
+                    action TRAP(0);
                 else
-                  action TRAP;
+                  action TRAP(0);
           else
             if ($a2.hi32 > 0)
             else
               if ($a2.hi32 == 0)
                 if ($a2.lo32 >= 2)
                 else
-                  action TRAP;
+                  action TRAP(0);
               else
-                action TRAP;
+                action TRAP(0);
     else
       if ($a1.hi32 > 0)
       else
@@ -258,18 +258,18 @@ if ($arch == 3221225655)
               if ($a2.hi32 == 0)
                 if ($a2.lo32 >= 2)
                 else
-                  action TRAP;
+                  action TRAP(0);
               else
-                action TRAP;
+                action TRAP(0);
         else
           if ($a2.hi32 > 0)
           else
             if ($a2.hi32 == 0)
               if ($a2.lo32 >= 2)
               else
-                action TRAP;
+                action TRAP(0);
             else
-              action TRAP;
+              action TRAP(0);
   # filter for syscall "read" (63) [priority: 65525]
   if ($syscall == 63)
     if ($a0.hi32 == 0)
@@ -332,18 +332,18 @@ if ($arch == 3221225730)
                 if ($a2.hi32 == 0)
                   if ($a2.lo32 >= 2)
                   else
-                    action TRAP;
+                    action TRAP(0);
                 else
-                  action TRAP;
+                  action TRAP(0);
           else
             if ($a2.hi32 > 0)
             else
               if ($a2.hi32 == 0)
                 if ($a2.lo32 >= 2)
                 else
-                  action TRAP;
+                  action TRAP(0);
               else
-                action TRAP;
+                action TRAP(0);
     else
       if ($a1.hi32 > 0)
       else
@@ -355,18 +355,18 @@ if ($arch == 3221225730)
               if ($a2.hi32 == 0)
                 if ($a2.lo32 >= 2)
                 else
-                  action TRAP;
+                  action TRAP(0);
               else
-                action TRAP;
+                action TRAP(0);
         else
           if ($a2.hi32 > 0)
           else
             if ($a2.hi32 == 0)
               if ($a2.lo32 >= 2)
               else
-                action TRAP;
+                action TRAP(0);
             else
-              action TRAP;
+              action TRAP(0);
   # filter for syscall "read" (63) [priority: 65525]
   if ($syscall == 63)
     if ($a0.hi32 == 0)
@@ -422,7 +422,7 @@ if ($arch == 1073741832)
       else
         if ($a2 >= 2)
         else
-          action TRAP;
+          action TRAP(0);
   # filter for syscall "read" (4003) [priority: 65531]
   if ($syscall == 4003)
     if ($a0 == 0)
@@ -464,18 +464,18 @@ if ($arch == 3221225480)
                 if ($a2.hi32 == 0)
                   if ($a2.lo32 >= 2)
                   else
-                    action TRAP;
+                    action TRAP(0);
                 else
-                  action TRAP;
+                  action TRAP(0);
           else
             if ($a2.hi32 > 0)
             else
               if ($a2.hi32 == 0)
                 if ($a2.lo32 >= 2)
                 else
-                  action TRAP;
+                  action TRAP(0);
               else
-                action TRAP;
+                action TRAP(0);
     else
       if ($a1.hi32 > 0)
       else
@@ -487,18 +487,18 @@ if ($arch == 3221225480)
               if ($a2.hi32 == 0)
                 if ($a2.lo32 >= 2)
                 else
-                  action TRAP;
+                  action TRAP(0);
               else
-                action TRAP;
+                action TRAP(0);
         else
           if ($a2.hi32 > 0)
           else
             if ($a2.hi32 == 0)
               if ($a2.lo32 >= 2)
               else
-                action TRAP;
+                action TRAP(0);
             else
-              action TRAP;
+              action TRAP(0);
   # filter for syscall "read" (5000) [priority: 65525]
   if ($syscall == 5000)
     if ($a0.hi32 == 0)
@@ -554,7 +554,7 @@ if ($arch == 3758096392)
       else
         if ($a2 >= 2)
         else
-          action TRAP;
+          action TRAP(0);
   # filter for syscall "read" (6000) [priority: 65531]
   if ($syscall == 6000)
     if ($a0 == 0)
@@ -596,18 +596,18 @@ if ($arch == 3221225493)
                 if ($a2.hi32 == 0)
                   if ($a2.lo32 >= 2)
                   else
-                    action TRAP;
+                    action TRAP(0);
                 else
-                  action TRAP;
+                  action TRAP(0);
           else
             if ($a2.hi32 > 0)
             else
               if ($a2.hi32 == 0)
                 if ($a2.lo32 >= 2)
                 else
-                  action TRAP;
+                  action TRAP(0);
               else
-                action TRAP;
+                action TRAP(0);
     else
       if ($a1.hi32 > 0)
       else
@@ -619,18 +619,18 @@ if ($arch == 3221225493)
               if ($a2.hi32 == 0)
                 if ($a2.lo32 >= 2)
                 else
-                  action TRAP;
+                  action TRAP(0);
               else
-                action TRAP;
+                action TRAP(0);
         else
           if ($a2.hi32 > 0)
           else
             if ($a2.hi32 == 0)
               if ($a2.lo32 >= 2)
               else
-                action TRAP;
+                action TRAP(0);
             else
-              action TRAP;
+              action TRAP(0);
   # filter for syscall "read" (3) [priority: 65525]
   if ($syscall == 3)
     if ($a0.hi32 == 0)
@@ -686,7 +686,7 @@ if ($arch == 1073741866)
       else
         if ($a2 >= 2)
         else
-          action TRAP;
+          action TRAP(0);
   # filter for syscall "read" (3) [priority: 65531]
   if ($syscall == 3)
     if ($a0 == 0)
@@ -728,18 +728,18 @@ if ($arch == 3221225715)
                 if ($a2.hi32 == 0)
                   if ($a2.lo32 >= 2)
                   else
-                    action TRAP;
+                    action TRAP(0);
                 else
-                  action TRAP;
+                  action TRAP(0);
           else
             if ($a2.hi32 > 0)
             else
               if ($a2.hi32 == 0)
                 if ($a2.lo32 >= 2)
                 else
-                  action TRAP;
+                  action TRAP(0);
               else
-                action TRAP;
+                action TRAP(0);
     else
       if ($a1.hi32 > 0)
       else
@@ -751,18 +751,18 @@ if ($arch == 3221225715)
               if ($a2.hi32 == 0)
                 if ($a2.lo32 >= 2)
                 else
-                  action TRAP;
+                  action TRAP(0);
               else
-                action TRAP;
+                action TRAP(0);
         else
           if ($a2.hi32 > 0)
           else
             if ($a2.hi32 == 0)
               if ($a2.lo32 >= 2)
               else
-                action TRAP;
+                action TRAP(0);
             else
-              action TRAP;
+              action TRAP(0);
   # filter for syscall "read" (63) [priority: 65525]
   if ($syscall == 63)
     if ($a0.hi32 == 0)

--- a/tests/63-live-trapx.c
+++ b/tests/63-live-trapx.c
@@ -1,0 +1,109 @@
+/**
+ * Seccomp Library test program
+ *
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include <signal.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include <seccomp.h>
+
+#include "util.h"
+
+
+#include <stdio.h>
+
+
+#define EXPECTED_REASON 1234
+
+static int trap_rc;
+
+static void _trap_handler(int signal, siginfo_t *info, void *ctx)
+{
+	if (info->si_errno == EXPECTED_REASON)
+		trap_rc = 0;
+	else
+		trap_rc = -EINVAL;
+}
+
+int trap_install(void)
+{
+	struct sigaction signal_handler;
+	sigset_t signal_mask;
+
+	trap_rc = -EBUSY;
+
+	memset(&signal_handler, 0, sizeof(signal_handler));
+	sigemptyset(&signal_mask);
+	sigaddset(&signal_mask, SIGSYS);
+
+	signal_handler.sa_sigaction = &_trap_handler;
+	signal_handler.sa_flags = SA_SIGINFO;
+	if (sigaction(SIGSYS, &signal_handler, NULL) < 0)
+		return -errno;
+	if (sigprocmask(SIG_UNBLOCK, &signal_mask, NULL))
+		return -errno;
+
+	return 0;
+}
+
+int main(int argc, char *argv[])
+{
+	scmp_filter_ctx ctx = NULL;
+	pid_t ppid;
+	int cnt, rc;
+
+	rc = trap_install();
+	if (rc != 0)
+		goto out;
+
+	ctx = seccomp_init(SCMP_ACT_ALLOW);
+	if (ctx == NULL)
+		return ENOMEM;
+
+	rc = seccomp_rule_add(ctx, SCMP_ACT_TRAPX(EXPECTED_REASON),
+			      SCMP_SYS(getppid), 0);
+	if (rc != 0)
+		goto out;
+
+	rc = seccomp_load(ctx);
+	if (rc != 0)
+		goto out;
+
+	ppid = getppid();
+	(void)ppid;
+
+	cnt = 0;
+	while (trap_rc == -EBUSY) {
+		sleep(1);
+		cnt++;
+
+		if (cnt > 5)
+			break;
+	}
+
+	if (trap_rc == 0)
+		rc = 161;
+
+out:
+	seccomp_release(ctx);
+	return (rc < 0 ? -rc : rc);
+}

--- a/tests/63-live-trapx.py
+++ b/tests/63-live-trapx.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+#
+# Seccomp Library test program
+#
+# Copyright (c) 2025 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+def test():
+    # The python signal handler doesn't support the si_errno field in the
+    # siginfo structure.  Therefore SCMP_ACT_TRAPX() cannot be tested in
+    # python
+    quit(160)
+
+test()
+
+# kate: syntax python;
+# kate: indent-mode python; space-indent on; indent-width 4; mixedindent off;

--- a/tests/63-live-trapx.tests
+++ b/tests/63-live-trapx.tests
@@ -1,0 +1,11 @@
+#
+# libseccomp regression test automation data
+#
+# Copyright (c) 2025 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+test type: live
+
+# Testname		API	Result
+63-live-trapx		1	TRAP

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -97,7 +97,8 @@ check_PROGRAMS = \
 	59-basic-empty_binary_tree \
 	60-sim-precompute \
 	61-sim-transactions \
-	62-sim-arch_transactions
+	62-sim-arch_transactions \
+	63-live-trapx
 
 EXTRA_DIST_TESTPYTHON = \
 	util.py \
@@ -160,7 +161,8 @@ EXTRA_DIST_TESTPYTHON = \
 	59-basic-empty_binary_tree.py \
 	60-sim-precompute.py \
 	61-sim-transactions.py \
-	62-sim-arch_transactions.py
+	62-sim-arch_transactions.py \
+	63-live-trapx.py
 
 EXTRA_DIST_TESTCFGS = \
 	01-sim-allow.tests \
@@ -224,7 +226,8 @@ EXTRA_DIST_TESTCFGS = \
 	59-basic-empty_binary_tree.tests \
 	60-sim-precompute.tests \
 	61-sim-transactions.tests \
-	62-sim-arch_transactions.tests
+	62-sim-arch_transactions.tests \
+	63-live-trapx.tests
 
 EXTRA_DIST_TESTSCRIPTS = \
 	38-basic-pfc_coverage.sh 38-basic-pfc_coverage.pfc \


### PR DESCRIPTION
This is my first cut at addressing Issue #466.  I'm open to discussion on other or better ways to handle it.

I decided to add `SCMP_ACT_TRAPX()` (similar to `SCMP_ACT_ERRNO()`) where the user can specify the lower 16 bits of the action.  These lower 16 bits are then fed into the si_errno field in the siginfo structure that is sent to the signal trap handler.

With that said, this feature has been in seccomp since it was added in 2012, and no user has requested it.  In fact, it looks like it was found by debugging and snooping around in the source code :).  I don't think most users care about it, so I have chosen to make this invisible to users by remapping `SCMP_ACT_TRAP` to `SCMP_ACT_TRAPX(0)`.  When users upgrade to a version of libseccomp with this feature, everything will behave as they have before.

If a user wants to use this feature, then they'll have to specifically use the `SCMP_ACT_TRAPX()` action.  Its usage is clearly outlined in test 63-live-trapx.c