### PR TITLE
BUG: Skip tests 60 and 61 on x32

### DIFF
--- a/tests/60-sim-precompute.tests
+++ b/tests/60-sim-precompute.tests
@@ -8,9 +8,9 @@
 test type: bpf-sim
 
 # Testname		Arch	Syscall	Arg0	Arg1	Arg2	Arg3	Arg4	Arg5	Result
-60-sim-precompute	all	0-10	N	N	N	N	N	N	ALLOW
-60-sim-precompute	all	1000	N	N	N	N	N	N	KILL
-60-sim-precompute	all	1001	N	N	N	N	N	N	KILL
+60-sim-precompute	all,-x32	0-10	N	N	N	N	N	N	ALLOW
+60-sim-precompute	all,-x32	1000	N	N	N	N	N	N	KILL
+60-sim-precompute	all,-x32	1001	N	N	N	N	N	N	KILL
 
 test type: bpf-sim-fuzz
 

--- a/tests/61-sim-transactions.tests
+++ b/tests/61-sim-transactions.tests
@@ -8,15 +8,15 @@
 test type: bpf-sim
 
 # Testname		Arch	Syscall		Arg0	Arg1	Arg2	Arg3	Arg4	Arg5	Result
-61-sim-transactions	all	1000		N	N	N	N	N	N	KILL
-61-sim-transactions	all	1001		N	N	N	N	N	N	KILL
-61-sim-transactions	all	1002		N	N	N	N	N	N	KILL
-61-sim-transactions	all	1003		N	N	N	N	N	N	KILL
-61-sim-transactions	all	1101-1104	N	N	N	N	N	N	KILL
-61-sim-transactions	all	1105		N	N	N	N	N	N	ALLOW
-61-sim-transactions	all	1106-1109	N	N	N	N	N	N	KILL
-61-sim-transactions	all	1110		N	N	N	N	N	N	ALLOW
-61-sim-transactions	all	1200-1210	N	N	N	N	N	N	ALLOW
+61-sim-transactions	all,-x32	1000		N	N	N	N	N	N	KILL
+61-sim-transactions	all,-x32	1001		N	N	N	N	N	N	KILL
+61-sim-transactions	all,-x32	1002		N	N	N	N	N	N	KILL
+61-sim-transactions	all,-x32	1003		N	N	N	N	N	N	KILL
+61-sim-transactions	all,-x32	1101-1104	N	N	N	N	N	N	KILL
+61-sim-transactions	all,-x32	1105		N	N	N	N	N	N	ALLOW
+61-sim-transactions	all,-x32	1106-1109	N	N	N	N	N	N	KILL
+61-sim-transactions	all,-x32	1110		N	N	N	N	N	N	ALLOW
+61-sim-transactions	all,-x32	1200-1210	N	N	N	N	N	N	ALLOW
 
 test type: bpf-sim-fuzz
 


### PR DESCRIPTION
x32 syscalls require the X32_SYSCALL_BIT (0x4000 0000) to be set, and thus syscalls less than that are invalid on the x32 architecture.  Tests 60 and 61 utilize syscalls less than 0x4000 0000, so skip those tests for the x32 arch.

Fixes Github Issue #472.

Reported-by: Sam James <sam@gentoo.org>