### PR TITLE
BUG: propagate notify_used when merging filter collections

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1259,6 +1259,10 @@ int db_col_merge(struct db_filter_col *col_dst, struct db_filter_col *col_src)
 	/* reset the precompute */
 	db_col_precompute_reset(col_dst);
 
+    /* propagate NOTIFY usage so NEW_LISTENER is requested on load */
+    if (col_src->notify_used)
+        col_dst->notify_used = true;
+
 	/* free the source */
 	col_src->filter_cnt = 0;
 	db_col_release(col_src);


### PR DESCRIPTION
Merging filter collections didn’t carry over notify_used; if the source had SCMP_ACT_NOTIFY rules, the merged filter could skip requesting SECCOMP_FILTER_FLAG_NEW_LISTENER, yielding no listener FD. This ORs the flag from source to destination to keep seccomp notification working.

This bug was discovered with [ZeroPath](https://zeropath.com).