### PR TITLE
doc: Add seccomp_transaction_start.3 to Makefile.am

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -51,6 +51,7 @@ dist_man3_MANS = \
 	man/man3/seccomp_syscall_resolve_name_arch.3 \
 	man/man3/seccomp_syscall_resolve_name_rewrite.3 \
 	man/man3/seccomp_syscall_resolve_num_arch.3 \
+	man/man3/seccomp_transaction_start.3 \
 	man/man3/seccomp_version.3 \
 	man/man3/seccomp_api_get.3 \
 	man/man3/seccomp_api_set.3


### PR DESCRIPTION
The transaction documentation was added in commit 72b013222026 ("api: add transaction support to the libseccomp API"), but we forgot to add the newly added transactions doc to the Makefile.  This commit adds it.

Fixes: 72b013222026 ("api: add transaction support to the libseccomp API")
Fixes: Github Issue #463