### PR TITLE
BUG: make sed command POSIX sed

### DIFF
--- a/src/arch-gperf-generate
+++ b/src/arch-gperf-generate
@@ -23,9 +23,12 @@ sys_csv_tmp=$(mktemp -t generate_syscalls_XXXXXX)
 
 # filter and prepare the syscall csv file
 cat $sys_csv | grep -v '^#' | nl -ba -s, -v0 | \
-    sed -e '{s|^[[:space:]]\+\([0-9]\+\),\([^,]\+\),\(.*\)|\2,\1,\3|;};' \
-        -e '{:r1; {s|\([^,]\+\)\(.*\)[^_]PNR|\1\2,__PNR_\1|g;}; t r1;};' \
-        -e '{s|,KV_|,SCMP_KV_|g;};' \
+    sed -E \
+        -e 's|^[[:space:]]+([0-9]+),([^,]+),(.*)|\2,\1,\3|' \
+        -e ':r1' \
+        -e 's|([^,]+)(.*)[^_]PNR|\1\2,__PNR_\1|g' \
+        -e 't r1' \
+        -e 's|,KV_|,SCMP_KV_|g' \
          > $sys_csv_tmp
 [[ $? -ne 0 ]] && exit 1
 


### PR DESCRIPTION
`\+` is a GNU extension. This will not work on BSD sed.
I believe both commands are functionally equivilent.