### PR TITLE
RFE: add versioned symbol support

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -49,7 +49,8 @@ SOURCES_ALL = \
 
 EXTRA_DIST = \
 	arch-syscall-validate arch-syscall-check \
-	arch-gperf-generate syscalls.csv syscalls.perf.template
+	arch-gperf-generate syscalls.csv syscalls.perf.template \
+	libseccomp.map
 
 TESTS = arch-syscall-check
 
@@ -65,6 +66,7 @@ libseccomp_la_CFLAGS = ${AM_CFLAGS} ${CODE_COVERAGE_CFLAGS} ${CFLAGS} \
 	-fPIC -DPIC -fvisibility=hidden
 libseccomp_la_LDFLAGS = ${AM_LDFLAGS} ${CODE_COVERAGE_LDFLAGS} ${LDFLAGS} \
 	-version-number ${VERSION_MAJOR}:${VERSION_MINOR}:${VERSION_MICRO}
+libseccomp_la_LDFLAGS += -Wl,--version-script=$(srcdir)/libseccomp.map
 
 EXTRA_DIST += syscalls.perf.c syscalls.perf
 CLEANFILES = syscalls.perf.c syscalls.perf

--- a/src/libseccomp.map
+++ b/src/libseccomp.map
@@ -1,0 +1,44 @@
+/* Avoid modifying a symbol set after it has been released
+   When adding features in a new release, add a new set
+   Removing features is a breaking change */
+LIBSECCOMP_2.7 {
+  global:
+    seccomp_api_get;
+    seccomp_api_set;
+    seccomp_arch_add;
+    seccomp_arch_exist;
+    seccomp_arch_native;
+    seccomp_arch_remove;
+    seccomp_arch_resolve_name;
+    seccomp_attr_get;
+    seccomp_attr_set;
+    seccomp_export_bpf;
+    seccomp_export_bpf_mem;
+    seccomp_export_pfc;
+    seccomp_init;
+    seccomp_load;
+    seccomp_merge;
+    seccomp_notify_alloc;
+    seccomp_notify_addfd;
+    seccomp_notify_fd;
+    seccomp_notify_free;
+    seccomp_notify_id_valid;
+    seccomp_notify_receive;
+    seccomp_notify_respond;
+    seccomp_precompute;
+    seccomp_release;
+    seccomp_reset;
+    seccomp_rule_add;
+    seccomp_rule_add_array;
+    seccomp_rule_add_exact;
+    seccomp_rule_add_exact_array;
+    seccomp_syscall_priority;
+    seccomp_syscall_resolve_name;
+    seccomp_syscall_resolve_name_arch;
+    seccomp_syscall_resolve_name_rewrite;
+    seccomp_syscall_resolve_num_arch;
+    seccomp_transaction_commit;
+    seccomp_transaction_reject;
+    seccomp_transaction_start;
+    seccomp_version;
+};


### PR DESCRIPTION
In order to improve reliable dependency resolution, I would like to add versioned symbols to the libraries that do not include them today.

This change is intended to support Fedora's recommendation that shared libraries provide versioned symbols: https://docs.fedoraproject.org/en-US/packaging-guidelines/C_and_C++/#_versioned_symbols

Please double-check the symbol files. If any symbols have been added very recently, they might not be in the symbol maps I've generated.