### PR TITLE
BUG: check direct syscall before multiplexed pseudo-syscall

### DIFF
--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -42,6 +42,13 @@
 int abi_syscall_resolve_name_munge(const struct arch_def *arch,
 				   const char *name)
 {
+	int sys = __NR_SCMP_ERROR;
+
+	/* Check if arch implements syscall directly and return its number */
+	sys = arch->syscall_resolve_name_raw(name);
+	if (sys != __NR_SCMP_ERROR) {
+		return sys;
+	}
 
 #define _ABI_SYSCALL_RES_NAME_CHK(NAME) \
 	if (!strcmp(name, #NAME)) return __PNR_##NAME;
@@ -79,7 +86,7 @@ int abi_syscall_resolve_name_munge(const struct arch_def *arch,
 	_ABI_SYSCALL_RES_NAME_CHK(shmget)
 	_ABI_SYSCALL_RES_NAME_CHK(shmctl)
 
-	return arch->syscall_resolve_name_raw(name);
+	return __NR_SCMP_ERROR;
 }
 
 /**

--- a/tests/30-sim-socket_syscalls.tests
+++ b/tests/30-sim-socket_syscalls.tests
@@ -44,9 +44,10 @@ test type: bpf-sim
 30-sim-socket_syscalls	+sh				352		0		1		2	N	N	N	ALLOW
 # direct syscalls
 30-sim-socket_syscalls	+x86,+ppc64le,+mipsel,+sh	accept		5		N		N	N	N	N	ALLOW
-30-sim-socket_syscalls	+x86,+ppc64le,+mipsel,+sh	accept		0		1		2	N	N	N	KILL
+30-sim-socket_syscalls	+x86				accept		0		1		2	N	N	N	KILL
+30-sim-socket_syscalls	+ppc64le,+mipsel,+sh		accept		0		1		2	N	N	N	ALLOW
 30-sim-socket_syscalls	+x86,+ppc64le,+mipsel,+sh	accept4		18		1		2	N	N	N	ALLOW
-30-sim-socket_syscalls	+x86,+ppc64le,+mipsel,+sh	accept4		0		1		2	N	N	N	KILL
+30-sim-socket_syscalls	+x86,+ppc64le,+mipsel,+sh	accept4		0		1		2	N	N	N	ALLOW
 30-sim-socket_syscalls	+x86_64				socket		0		1		2	N	N	N	ALLOW
 30-sim-socket_syscalls	+x86_64				connect		0		1		2	N	N	N	ALLOW
 30-sim-socket_syscalls	+x86_64				accept4		0		1		2	N	N	N	ALLOW

--- a/tests/33-sim-socket_syscalls_be.tests
+++ b/tests/33-sim-socket_syscalls_be.tests
@@ -21,9 +21,10 @@ test type: bpf-sim
 33-sim-socket_syscalls_be	+s390,+s390x		373		0		1		2	N	N	N	ALLOW
 33-sim-socket_syscalls_be	+ppc			338		0		1		2	N	N	N	ALLOW
 33-sim-socket_syscalls_be	+s390,+s390x,+ppc	accept		5		N		N	N	N	N	ALLOW
-33-sim-socket_syscalls_be	+s390,+s390x,+ppc	accept		0		1		2	N	N	N	KILL
+33-sim-socket_syscalls_be	+s390,+s390x		accept		0		1		2	N	N	N	KILL
+33-sim-socket_syscalls_be	+ppc			accept		0		1		2	N	N	N	ALLOW
 33-sim-socket_syscalls_be	+s390,+s390x,+ppc	accept4		18		1		2	N	N	N	ALLOW
-33-sim-socket_syscalls_be	+s390,+s390x,+ppc	accept4		0		1		2	N	N	N	KILL
+33-sim-socket_syscalls_be	+s390,+s390x,+ppc	accept4		0		1		2	N	N	N	ALLOW
 
 test type: bpf-valgrind
 


### PR DESCRIPTION
Docker 29.4.2 removed socketcall(2) from the default seccomp profile. On s390x, this broke socket operations:
```
  # strace curl icanhazip.com
  socket(AF_UNIX, SOCK_STREAM, 0) = -1 ENOSYS (Function not implemented)

  # scmp_sys_resolver -a s390x socket
  -101

  # ausyscall s390x socket
  socket             359
```
The abi_syscall_resolve_name_munge() function was returning __PNR_socket (-101) instead of checking if arch implements socket(2) directly (359).

Fix by checking arch->syscall_resolve_name_raw() first, only falling back to multiplexed pseudo-syscalls if the direct implementation doesn't exist.

Affects socket and IPC syscalls on architectures with direct implementations (s390x, aarch64, etc).