### PR TITLE
arch-syscall-check: verify #ifdef __NR_ guards match __SNR_ define names

### DIFF
--- a/src/arch-syscall-check
+++ b/src/arch-syscall-check
@@ -50,6 +50,44 @@ function check_pnr() {
 	[[ $? -eq 1 ]] && return 0 || return 1
 }
 
+function check_snr_ifdef() {
+	# Verify that each "#ifdef __NR_<name>" guard immediately preceding a
+	# "#define __SNR_<name>" uses the same syscall name as the define.
+	# A mismatch (e.g. "#ifdef __NR_foo" followed by "#define __SNR_bar")
+	# means the define will silently use the wrong guard and may resolve
+	# to __PNR_bar even when __NR_foo is present on the target arch.
+	local mismatch=0
+	local ifdef_name=""
+	local lineno=0
+
+	while IFS= read -r line; do
+		(( lineno++ ))
+
+		if [[ "$line" =~ ^#ifdef[[:space:]]+__NR_(.+)$ ]]; then
+			ifdef_name="${BASH_REMATCH[1]}"
+		elif [[ -n "$ifdef_name" ]]; then
+			if [[ "$line" =~ ^#define[[:space:]]+__SNR_([^[:space:]]+) ]]; then
+				snr_name="${BASH_REMATCH[1]}"
+				if [[ "$ifdef_name" != "$snr_name" ]]; then
+					echo "MISMATCH at $SYSCALL_HDR:$lineno:" \
+					     "#ifdef __NR_$ifdef_name" \
+					     "but #define __SNR_$snr_name"
+					mismatch=1
+				fi
+				ifdef_name=""
+			elif [[ "$line" =~ ^#ifdef || "$line" =~ ^#define || \
+			        "$line" =~ ^#else   || "$line" =~ ^#endif ]]; then
+				# Any other preprocessor directive clears the
+				# pending ifdef_name without a match being needed
+				# (e.g. unconditional defines have no #ifdef guard)
+				ifdef_name=""
+			fi
+		fi
+	done < "$SYSCALL_HDR"
+
+	return $mismatch
+}
+
 rc=0
 
 echo ">>> CHECKING FOR MISSING __SNR_syscall VALUES"
@@ -58,6 +96,10 @@ rc=$(( $rc + $? ))
 
 echo ">>> CHECKING FOR MISSING __PNR_syscall VALUES"
 check_pnr
+rc=$(( $rc + $? ))
+
+echo ">>> CHECKING FOR MISMATCHED __SNR_syscall/#ifdef __NR_syscall NAMES"
+check_snr_ifdef
 rc=$(( $rc + $? ))
 
 exit $rc


### PR DESCRIPTION
## Problem

`src/arch-syscall-check` already verifies that the *set* of syscall names in
`syscalls.csv` matches the set of `__SNR_` defines in `seccomp-syscalls.h`.
However it does not verify that each `#ifdef __NR_<name>` guard immediately
preceding a `#define __SNR_<name>` uses the **same** syscall name as the
define it guards.

A mismatch — e.g. `#ifdef __NR_foo` guarding `#define __SNR_bar` — means the
define will silently resolve to `__PNR_bar` (not present) even when `__NR_foo`
is defined by the kernel headers.  The existing name-set diff (using `sort -u`)
would not catch this because both names appear in the header; only the pairing
is wrong.

Fixes: Github Issue #315

## Fix

Add `check_snr_ifdef()` to `src/arch-syscall-check`.  The function reads
`seccomp-syscalls.h` line by line and reports any `#ifdef __NR_<X>` /
`#define __SNR_<Y>` pairing where X ≠ Y, along with the file and line number.

Any other preprocessor directive between an `#ifdef` and the expected
`#define` (including unconditional defines that carry no `#ifdef` guard)
resets the pending guard name so only genuine guarded pairs are checked.

The exit code from `check_snr_ifdef()` is accumulated into the script's
overall return value alongside the existing `check_snr()` and `check_pnr()`
checks, so a guard mismatch fails the `arch-syscall-check` test that runs
as part of `make check`.

## Testing

- Clean pass on the current `seccomp-syscalls.h` (all guards match).
- Injecting `#ifdef __NR_accept_TYPO` in place of `#ifdef __NR_accept`
  produces: `MISMATCH at …seccomp-syscalls.h:313: #ifdef __NR_accept_TYPO but #define __SNR_accept`
  and exits 1.
- `make check` passes (PASS: arch-syscall-check, PASS: regression).