### PR TITLE
python: replace deprecated 'setup.py install' with PEP 517 wheel install

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -31,7 +31,7 @@ runs:
   - run: |
       sudo apt-get install -y python3 python3-setuptools python3-pip
       python3 -m pip install --upgrade pip
-      python3 -m pip install cython
+      python3 -m pip install cython wheel build installer
       # Add cython to the path
       echo "$HOME/.local/bin" >> $GITHUB_PATH
     shell: bash

--- a/src/python/Makefile.am
+++ b/src/python/Makefile.am
@@ -29,7 +29,15 @@ PY_BUILD_1 = ${PY_DISTUTILS} build
 PY_BUILD_ = ${PY_BUILD_0}
 PY_BUILD = ${PY_BUILD_@AM_V@}
 
-PY_INSTALL = ${PY_DISTUTILS} install
+# Build a wheel via PEP 517 (python -m build --no-isolation) to avoid the
+# deprecated "setup.py install" invocation.  The --no-isolation flag reuses
+# the in-tree build environment rather than creating an isolated venv.
+PY_BDIST_WHEEL = \
+	VERSION_RELEASE="@PACKAGE_VERSION@" \
+	CPPFLAGS="-I\${top_srcdir}/include ${AM_CPPFLAGS} ${CPPFLAGS}" \
+	CFLAGS="${AM_CFLAGS} ${CFLAGS}" \
+	LDFLAGS="${AM_LDFLAGS} ${LDFLAGS}" \
+	${PYTHON} -m build --wheel --no-isolation
 
 EXTRA_DIST = libseccomp.pxd seccomp.pyx setup.py
 
@@ -40,12 +48,14 @@ build: ../libseccomp.la libseccomp.pxd seccomp.pyx setup.py
 	${PY_BUILD} && touch build
 
 install-exec-local: build
-	${PY_INSTALL} --install-lib=${DESTDIR}/${pyexecdir} \
-		--record=${DESTDIR}/${pyexecdir}/install_files.txt
+	${PY_BDIST_WHEEL}
+	${PYTHON} -m installer \
+		--destdir=${DESTDIR}/ \
+		--prefix=${prefix} \
+		dist/seccomp-*.whl
 
 uninstall-local:
-	cat ${DESTDIR}/${pyexecdir}/install_files.txt | xargs ${RM} -f
-	${RM} -f ${DESTDIR}/${pyexecdir}/install_files.txt
+	${PYTHON} -m pip uninstall --yes seccomp
 
 clean-local:
 	[ ${srcdir} = ${builddir} ] || ${RM} -f ${builddir}/seccomp.pyx


### PR DESCRIPTION
## Problem

Running `make install` with `--enable-python` prints a deprecation warning on
every invocation:

```
SetuptoolsDeprecationWarning: setup.py install is deprecated.
Please avoid running ``setup.py`` directly.
Instead, use pypa/build, pypa/installer or other standards-based tools.
```

The root cause is `src/python/Makefile.am` invoking `setup.py install` in
`install-exec-local` via `PY_INSTALL = ${PY_DISTUTILS} install`.  This was
not fixed by the earlier distutils→setuptools migration (PR #374) which
addressed the *import* deprecation but not the *command* deprecation.

Fixes: Github Issue #444

## Fix

Replace the `install-exec-local` target with a two-step PEP 517 workflow:

1. **Build** a wheel using `python -m build --wheel --no-isolation`.
   The `--no-isolation` flag reuses the in-tree build environment (same
   compiler flags, same libseccomp.a) rather than creating an isolated venv.
   This does **not** invoke the deprecated `setup.py install` command path.

2. **Install** the wheel using `python -m installer --destdir --prefix`.
   `pypa/installer` is a minimal, standards-based wheel installer that writes
   the dist-info/RECORD used by `pip uninstall` for clean removal.

The `uninstall-local` target is updated to use `pip uninstall --yes seccomp`,
which reads the dist-info/RECORD written by installer — the modern replacement
for the old `install_files.txt` record mechanism.

The `build` / `PY_BUILD` target (used by `make check-build` and `make check`)
is **unchanged** — it still calls `setup.py build` which is not deprecated.

`.github/actions/setup/action.yml` is updated to install the additional
Python build-time dependencies (`wheel`, `build`, `installer`) alongside the
existing `cython`.

## Testing

- `make install DESTDIR=/tmp/test prefix=/usr`: zero deprecation warnings,
  `seccomp.cpython-*.so` and `seccomp-*.dist-info` correctly installed under
  `${DESTDIR}/usr/lib/python*/site-packages/`.
- `make check-build`, `make check`: both pass; the `build` target is
  unaffected by this change.
- `bash src/arch-syscall-check`: PASS.
